### PR TITLE
Fix table horizontal overflow

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -161,6 +161,8 @@ stateDiagram-v2
 
 ## Tables
 
+### Compact Table (fits in view)
+
 | Feature | Status | Notes |
 |---------|--------|-------|
 | File tree sidebar | Done | Recursive, filterable |
@@ -172,6 +174,20 @@ stateDiagram-v2
 | Multi-pane viewing | Done | Up to 4 panes |
 | Full-text search | Done | With highlight + scroll |
 | Image rendering | Done | Local + external + broken fallback |
+
+### Wide Table (horizontal scroll)
+
+The table below has many columns and should scroll horizontally instead of overflowing off-screen.
+
+| Component | Language | Framework | Build Tool | Test Framework | Lines of Code | Status | Owner | Priority | Sprint | Dependencies | Notes |
+|-----------|----------|-----------|------------|----------------|---------------|--------|-------|----------|--------|--------------|-------|
+| FileTree | TypeScript | Svelte 5 | Vite 6 | vitest + testing-library | ~250 | Complete | Frontend Team | P0 | Sprint 1 | tree-utils, persistence | Keyboard nav with arrow keys, expand/collapse |
+| MarkdownViewer | TypeScript | Svelte 5 | Vite 6 | vitest + testing-library | ~220 | Complete | Frontend Team | P0 | Sprint 1 | markdown service, highlight service | Renders HTML from marked, triggers mermaid/bob |
+| Sidebar | TypeScript | Svelte 5 | Vite 6 | vitest + testing-library | ~180 | Complete | Frontend Team | P0 | Sprint 1 | FileTree, SearchResults, filesystem | Filter bar, search toggle, sort controls |
+| ContentArea | TypeScript | Svelte 5 | Vite 6 | vitest + testing-library | ~150 | Complete | Frontend Team | P1 | Sprint 2 | MarkdownViewer, persistence | Multi-pane CSS grid layout, Ctrl+Click to open |
+| filesystem.rs | Rust | Tauri 2.10 | Cargo | cargo test | ~200 | Complete | Backend Team | P0 | Sprint 1 | walkdir, serde | Directory tree, file reading, full-text search |
+| watcher.rs | Rust | Tauri 2.10 | Cargo | cargo test | ~100 | Complete | Backend Team | P0 | Sprint 1 | notify 7 | Native file system watcher, emits Tauri events |
+| diagram.rs | Rust | Tauri 2.10 | Cargo | cargo test | ~50 | Complete | Backend Team | P1 | Sprint 2 | svgbob 0.7 | ASCII art to SVG conversion with dark theme colors |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planning-central",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "log",
  "notify",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Planning Central",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.planningcentral.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/app.css
+++ b/src/app.css
@@ -153,10 +153,14 @@ html, body, #app {
   margin-bottom: 0.25em;
 }
 
+.markdown-body .table-wrapper {
+  overflow-x: auto;
+  margin-bottom: 1em;
+}
+
 .markdown-body table {
   width: 100%;
   border-collapse: collapse;
-  margin-bottom: 1em;
 }
 
 .markdown-body th,

--- a/src/lib/services/markdown.test.ts
+++ b/src/lib/services/markdown.test.ts
@@ -136,6 +136,32 @@ describe("renderMarkdown", () => {
   });
 });
 
+describe("renderMarkdown tables", () => {
+  it("wraps tables in a scrollable container", async () => {
+    const md = "| Col A | Col B |\n|-------|-------|\n| 1 | 2 |";
+    const html = await renderMarkdown(md);
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, "text/html");
+    const wrapper = doc.querySelector(".table-wrapper");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.querySelector("table")).not.toBeNull();
+  });
+
+  it("renders table cell content correctly (not [object Object])", async () => {
+    const md = "| Col A | Col B |\n|-------|-------|\n| hello | world |";
+    const html = await renderMarkdown(md);
+    expect(html).toContain("<th>Col A</th>");
+    expect(html).toContain("<td>hello</td>");
+    expect(html).not.toContain("[object Object]");
+  });
+
+  it("table wrapper has the correct class", async () => {
+    const md = "| Col A | Col B |\n|-------|-------|\n| 1 | 2 |";
+    const html = await renderMarkdown(md);
+    expect(html).toContain('class="table-wrapper"');
+  });
+});
+
 describe("renderMermaidDiagrams", () => {
   beforeEach(() => {
     vi.mocked(mermaid.run).mockReset();

--- a/src/lib/services/markdown.ts
+++ b/src/lib/services/markdown.ts
@@ -71,6 +71,13 @@ function wrapWithLineNumbers(highlighted: string, text: string, langClass: strin
 
 // Create a configured Marked instance with syntax highlighting and mermaid support
 const marked = new Marked({
+  hooks: {
+    postprocess(html) {
+      return html
+        .replace(/<table>/g, '<div class="table-wrapper"><table>')
+        .replace(/<\/table>/g, '</table></div>');
+    },
+  },
   renderer: {
     image({ href, title, text }: { href: string; title?: string | null; text: string }) {
       const resolvedHref = resolveImageSrc(href, currentMarkdownDir);


### PR DESCRIPTION
## Summary
- Fix wide markdown tables overflowing their container and overlapping adjacent panes
- Wrap all rendered `<table>` elements in a `<div class="table-wrapper">` with `overflow-x: auto` via marked's `postprocess` hook
- Add wide table demo to the Rendering Museum (`docs/test.md`) to showcase horizontal scrolling
- Bump version to 0.3.1

## Test plan
- [x] 139 frontend tests pass (3 new table tests added)
- [x] Verified compact tables render normally
- [x] Verified wide tables show horizontal scrollbar instead of overflowing
- [x] User confirmed fix working in compiled binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)