### PR TITLE
Add markdown editor with scroll sync and active line highlighting

### DIFF
--- a/docs/How to Use Planning Central.md
+++ b/docs/How to Use Planning Central.md
@@ -122,6 +122,44 @@ Supported diagram types include flowcharts, sequence diagrams, class diagrams, s
 
 ---
 
+## Editing Markdown
+
+Planning Central includes a built-in split-pane editor so you can edit files without leaving the app.
+
+### Entering Edit Mode
+
+Each pane header has a **view/edit toggle** — an eye icon (view) and a pencil icon (edit). The active mode is highlighted. Click the pencil to enter edit mode, or press **Ctrl+E** to toggle the active pane.
+
+### Split Editor
+
+In edit mode, the pane splits in two:
+
+- **Left side** — a CodeMirror text editor with syntax highlighting and line numbers
+- **Right side** — a live preview that updates as you type (including Mermaid diagrams)
+
+### Scroll Sync & Active Line
+
+The editor and preview panes stay in sync as you work:
+
+- **Scroll sync** — scrolling either pane (editor or preview) proportionally scrolls the other
+- **Active line highlight** — as you move your cursor in the editor, the corresponding rendered element in the preview is highlighted with a subtle blue border
+- **Table cell targeting** — when your cursor is on a table row, the preview highlights the specific cell under the cursor, not just the first cell in the row
+
+### Saving
+
+- **Auto-save** — changes are saved to disk automatically 1 second after you stop typing
+- **Ctrl+S** — saves immediately (and cancels the auto-save timer)
+
+### Navigating While Editing
+
+Clicking a file in the sidebar while in edit mode loads the new file into the editor — you stay in edit mode. Click the eye icon or press **Ctrl+E** to return to view mode.
+
+### Multi-Pane Editing
+
+Each pane toggles independently. You can have one pane in edit mode and another in view mode.
+
+---
+
 ## Live File Watching
 
 Planning Central watches your folder for changes in real time. If you edit a markdown file in another editor (or if a tool like Claude Code writes files), the sidebar and content area update automatically — no refresh needed.
@@ -135,6 +173,11 @@ Planning Central watches your folder for changes in real time. If you edit a mar
 | **Up/Down Arrow** | Navigate file tree (auto-selects files) |
 | **Enter** | Expand/collapse focused directory |
 | **Tab** | Move focus between sidebar and content |
+| **Ctrl+E** | Toggle edit/view mode on active pane |
+| **Ctrl+S** | Save immediately (in edit mode) |
+| **Ctrl+Click** | Open file in a new pane |
+| **Ctrl+W** | Close active pane |
+| **Ctrl+1/2/3/4** | Switch to pane 1, 2, 3, or 4 |
 
 ---
 

--- a/docs/desktopMarkdownAndDiagramViewerPlan.md
+++ b/docs/desktopMarkdownAndDiagramViewerPlan.md
@@ -19,7 +19,7 @@ You want a central place to hold all your planning markdown files with the abili
 | File watching | **notify** crate (7.x) | Native OS events, cross-platform |
 | Styling | **Plain CSS + Svelte scoped styles** | ~5 components don't justify Tailwind |
 
-## Prerequisites
+## Prerequisitesssssss
 
 - Rust toolchain (`rustup`) — needed for Tauri
 - Node.js 18+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,20 @@
 {
   "name": "planning-central",
-  "version": "0.1.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "planning-central",
-      "version": "0.1.0",
+      "version": "0.3.1",
       "dependencies": {
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "@codemirror/view": "^6.39.15",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",
+        "codemirror": "^6.0.2",
         "highlight.js": "^11.11.1",
         "marked": "^17.0.3",
         "mermaid": "^11.12.3"
@@ -180,6 +185,147 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.1.tgz",
       "integrity": "sha512-71eTYMzYXYSFPrbg/ZwftSaSDld7UYlS8OQa3lNnn9jzNtpFbaReRRyghzqS7rI3CDaorqpPJJcXGHK+FE1TVQ=="
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
+      "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
+      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
+      "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
+      "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.4.tgz",
+      "integrity": "sha512-ABc9vJ8DEmvOWuH26P3i8FpMWPQkduD9Rvba5iwb6O3hxASgclm3T3krGo8NASXkHCidz6b++LWlzWIUfEPSWw==",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
+      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.39.15",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.15.tgz",
+      "integrity": "sha512-aCWjgweIIXLBHh7bY6cACvXuyrZ0xGafjQ2VInjp4RM4gMfscK5uESiNdrH0pE+e1lZr2B4ONGsjchl2KsKZzg==",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
@@ -813,6 +959,71 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw=="
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.1.tgz",
+      "integrity": "sha512-PYAKeUVBo3HFThruRyp/iK91SwiZJnzXh8QzkQlwijB5y+N5iB28+iLk78o2zmKqqV0uolNhCwFqB8LA7b0Svg==",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="
     },
     "node_modules/@mermaid-js/parser": {
       "version": "1.0.0",
@@ -2046,6 +2257,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -2066,6 +2291,11 @@
       "dependencies": {
         "layout-base": "^1.0.0"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "node_modules/css-tree": {
       "version": "3.1.0",
@@ -3486,6 +3716,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="
+    },
     "node_modules/stylis": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
@@ -3906,6 +4141,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "planning-central",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -28,8 +28,13 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/state": "^6.5.4",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@codemirror/view": "^6.39.15",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
+    "codemirror": "^6.0.2",
     "highlight.js": "^11.11.1",
     "marked": "^17.0.3",
     "mermaid": "^11.12.3"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "log",
  "notify",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.1"
+version = "0.4.0"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/src/commands/filesystem.rs
+++ b/src-tauri/src/commands/filesystem.rs
@@ -85,6 +85,11 @@ pub fn read_file_contents(path: String) -> Result<String, String> {
     fs::read_to_string(&path).map_err(|e| format!("Failed to read file {}: {}", path, e))
 }
 
+#[tauri::command]
+pub fn write_file_contents(path: String, content: String) -> Result<(), String> {
+    fs::write(&path, &content).map_err(|e| format!("Failed to write file {}: {}", path, e))
+}
+
 /// Returns the absolute path to the docs/ directory.
 /// In dev mode: navigates up from the exe in src-tauri/target/debug/
 /// In production: looks for docs/ next to the executable.
@@ -357,5 +362,34 @@ mod tests {
         let results = search_files(dir.path().to_string_lossy().to_string(), "keyword".into()).unwrap();
 
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_write_file_contents_creates_new_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("new_file.md");
+
+        write_file_contents(file_path.to_string_lossy().to_string(), "# New File".into()).unwrap();
+
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "# New File");
+    }
+
+    #[test]
+    fn test_write_file_contents_overwrites_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("existing.md");
+        fs::write(&file_path, "old content").unwrap();
+
+        write_file_contents(file_path.to_string_lossy().to_string(), "new content".into()).unwrap();
+
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "new content");
+    }
+
+    #[test]
+    fn test_write_file_contents_error_on_invalid_path() {
+        let result = write_file_contents("/nonexistent/dir/file.md".into(), "content".into());
+        assert!(result.is_err());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::filesystem::read_directory_tree,
             commands::filesystem::read_file_contents,
+            commands::filesystem::write_file_contents,
             commands::filesystem::get_docs_path,
             commands::filesystem::get_help_content,
             commands::filesystem::search_files,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Planning Central",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "identifier": "com.planningcentral.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,6 +6,7 @@
   import {
     readDirectoryTree,
     readFileContents,
+    writeFileContents,
     startWatching,
     getDocsPath,
     getHelpContent,
@@ -45,6 +46,8 @@
   let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
   let highlightText = $state("");
   let highlightKey = $state(0);
+  const recentOwnWrites = new Set<string>();
+  let savedPaneBeforeHelp: { path: string; content: string; editMode?: boolean } | null = null;
 
   let sortedTree: FileEntry[] = $derived(sortEntries(rawTree, sortMode));
   let tree: FileEntry[] = $derived(filterEntries(sortedTree, filterQuery));
@@ -52,6 +55,9 @@
   // The "selected" path for sidebar highlighting is the active pane's path
   let selectedPath: string = $derived(
     panes.find((p) => p.id === activePaneId)?.path ?? ""
+  );
+  let helpActive: boolean = $derived(
+    panes.find((p) => p.id === activePaneId)?.readOnly === true
   );
 
   async function loadTree() {
@@ -76,7 +82,7 @@
         activePaneId = id;
       } else {
         panes = panes.map((p) =>
-          p.id === activePaneId ? { ...p, path, content } : p
+          p.id === activePaneId ? { ...p, path, content, readOnly: false } : p
         );
       }
       saveLastSelectedPath(path);
@@ -126,6 +132,45 @@
     activePaneId = id;
     const pane = panes.find((p) => p.id === id);
     if (pane) saveLastSelectedPath(pane.path);
+  }
+
+  async function handleToggleEdit(id: string) {
+    const pane = panes.find((p) => p.id === id);
+    if (!pane || pane.readOnly) return;
+
+    if (pane.editMode) {
+      // Switching from edit → view: reload from disk to show latest
+      try {
+        const content = await readFileContents(pane.path);
+        panes = panes.map((p) =>
+          p.id === id ? { ...p, editMode: false, content } : p
+        );
+      } catch {
+        panes = panes.map((p) =>
+          p.id === id ? { ...p, editMode: false } : p
+        );
+      }
+    } else {
+      // Switching from view → edit
+      panes = panes.map((p) =>
+        p.id === id ? { ...p, editMode: true } : p
+      );
+    }
+  }
+
+  async function handleSave(path: string, content: string) {
+    try {
+      recentOwnWrites.add(path);
+      await writeFileContents(path, content);
+      // Update pane content to reflect saved state
+      panes = panes.map((p) =>
+        p.path === path ? { ...p, content } : p
+      );
+      setTimeout(() => recentOwnWrites.delete(path), 500);
+    } catch (e) {
+      console.error("Failed to save file:", e);
+      recentOwnWrites.delete(path);
+    }
   }
 
   function findEntryByPath(items: FileEntry[], path: string): FileEntry | undefined {
@@ -214,16 +259,42 @@
   }
 
   async function handleHelp() {
+    // If already viewing help, restore the previous pane state
+    if (helpActive && savedPaneBeforeHelp) {
+      try {
+        const saved = savedPaneBeforeHelp;
+        const content = await readFileContents(saved.path);
+        panes = panes.map((p) =>
+          p.id === activePaneId
+            ? { ...p, path: saved.path, content, readOnly: false, editMode: saved.editMode }
+            : p
+        );
+        saveLastSelectedPath(saved.path);
+        savedPaneBeforeHelp = null;
+      } catch (e) {
+        console.error("Failed to restore previous file:", e);
+        savedPaneBeforeHelp = null;
+      }
+      return;
+    }
+
     try {
+      // Save current pane state before opening help
+      const activePane = panes.find((p) => p.id === activePaneId);
+      if (activePane && !activePane.readOnly) {
+        savedPaneBeforeHelp = { path: activePane.path, content: activePane.content, editMode: activePane.editMode };
+      }
+
       const content = await getHelpContent();
       if (panes.length === 0) {
         const id = createPaneId();
-        panes = [{ id, path: "How to Use Planning Central.md", content }];
+        panes = [{ id, path: "How to Use Planning Central.md", content, readOnly: true, editMode: false }];
         activePaneId = id;
+        savedPaneBeforeHelp = null;
       } else {
         panes = panes.map((p) =>
           p.id === activePaneId
-            ? { ...p, path: "How to Use Planning Central.md", content }
+            ? { ...p, path: "How to Use Planning Central.md", content, readOnly: true, editMode: false }
             : p
         );
       }
@@ -245,6 +316,11 @@
     if (event.ctrlKey && event.key === "w") {
       event.preventDefault();
       if (activePaneId) handleClosePane(activePaneId);
+    }
+    // Ctrl+E: toggle edit/view mode on active pane
+    if (event.ctrlKey && event.key === "e") {
+      event.preventDefault();
+      if (activePaneId) handleToggleEdit(activePaneId);
     }
     // Ctrl+1/2/3/4: switch panes
     if (event.ctrlKey && event.key >= "1" && event.key <= "4") {
@@ -312,10 +388,14 @@
         console.error("Failed to start file watcher:", e);
       }
 
-      // Listen for file changes — update ALL open panes with that file
+      // Listen for file changes — update open panes (skip own writes and edit-mode panes)
       unlistenFn = await listen<string[]>("file-changed", async (event) => {
         await loadTree();
         for (const pane of panes) {
+          // Skip panes in edit mode — don't overwrite the user's in-progress edits
+          if (pane.editMode) continue;
+          // Skip paths we just wrote ourselves (feedback loop prevention)
+          if (recentOwnWrites.has(pane.path)) continue;
           if (event.payload.some((p) => p === pane.path)) {
             try {
               const content = await readFileContents(pane.path);
@@ -338,8 +418,8 @@
 </script>
 
 <div class="app-layout">
-  <Sidebar entries={tree} {selectedPath} onselect={(path, event, lineContent) => handleSelect(path, event, lineContent)} onchangefolder={handleChangeFolder} {sortMode} onsortchange={handleSortChange} onhelp={handleHelp} {filterQuery} onfilterchange={handleFilterChange} {searchMode} onsearchmodechange={handleSearchModeChange} {searchResults} {searchQuery} onsearchchange={handleSearchChange} {isSearching} />
-  <ContentArea {panes} {activePaneId} {layoutMode} onlayoutchange={handleLayoutChange} onclosepane={handleClosePane} onactivatepane={handleActivatePane} {highlightText} {highlightKey} />
+  <Sidebar entries={tree} {selectedPath} onselect={(path, event, lineContent) => handleSelect(path, event, lineContent)} onchangefolder={handleChangeFolder} {sortMode} onsortchange={handleSortChange} onhelp={handleHelp} {helpActive} {filterQuery} onfilterchange={handleFilterChange} {searchMode} onsearchmodechange={handleSearchModeChange} {searchResults} {searchQuery} onsearchchange={handleSearchChange} {isSearching} />
+  <ContentArea {panes} {activePaneId} {layoutMode} onlayoutchange={handleLayoutChange} onclosepane={handleClosePane} onactivatepane={handleActivatePane} ontoggleedit={handleToggleEdit} onsave={handleSave} {highlightText} {highlightKey} />
 </div>
 
 <style>

--- a/src/app.css
+++ b/src/app.css
@@ -321,3 +321,33 @@ mark.search-highlight {
   70% { background: rgba(224, 175, 104, 0.15); border-left-color: rgba(224, 175, 104, 0.7); }
   100% { background: rgba(224, 175, 104, 0.05); border-left-color: rgba(224, 175, 104, 0.3); }
 }
+
+/* Active line highlight — block-level blue background in preview when editing */
+.active-line-block {
+  background: rgba(122, 162, 247, 0.12) !important;
+  outline: 2px solid rgba(122, 162, 247, 0.4);
+  outline-offset: -2px;
+  border-radius: 2px;
+  transition: background 0.15s ease, outline-color 0.15s ease;
+}
+
+/* Active line highlight — single line within a code block */
+.active-line-overlay {
+  background: rgba(122, 162, 247, 0.15);
+  border-left: 3px solid rgba(122, 162, 247, 0.5);
+}
+
+/* Search highlight — block-level fallback when text spans multiple elements */
+.search-highlight-block {
+  background: rgba(224, 175, 104, 0.15) !important;
+  border-left: 3px solid rgba(224, 175, 104, 0.6);
+  padding-left: 8px;
+  border-radius: 2px;
+  animation: block-highlight-fade 3s ease-out forwards;
+}
+
+@keyframes block-highlight-fade {
+  0% { background: rgba(224, 175, 104, 0.2) !important; border-left-color: rgba(224, 175, 104, 0.7); }
+  70% { background: rgba(224, 175, 104, 0.15) !important; border-left-color: rgba(224, 175, 104, 0.5); }
+  100% { background: rgba(224, 175, 104, 0.08) !important; border-left-color: rgba(224, 175, 104, 0.3); }
+}

--- a/src/lib/components/ContentArea.svelte
+++ b/src/lib/components/ContentArea.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import MarkdownViewer from "./MarkdownViewer.svelte";
+  import EditablePane from "./EditablePane.svelte";
   import type { OpenPane, LayoutMode } from "../types";
 
   let {
@@ -9,6 +10,8 @@
     onlayoutchange,
     onclosepane,
     onactivatepane,
+    ontoggleedit,
+    onsave,
     highlightText = "",
     highlightKey = 0,
   }: {
@@ -18,6 +21,8 @@
     onlayoutchange?: (mode: LayoutMode) => void;
     onclosepane?: (id: string) => void;
     onactivatepane?: (id: string) => void;
+    ontoggleedit?: (id: string) => void;
+    onsave?: (path: string, content: string) => void;
     highlightText?: string;
     highlightKey?: number;
   } = $props();
@@ -46,20 +51,54 @@
           <span class="pane-filename" title={pane.path}>
             {pane.path.split(/[\\/]/).pop() ?? ""}
           </span>
-          <button
-            class="close-btn"
-            title="Close pane"
-            onclick={(e) => { e.stopPropagation(); onclosepane?.(pane.id); }}
-          >×</button>
+          <div class="pane-actions">
+            {#if pane.readOnly}
+              <span class="read-only-badge">Read Only</span>
+            {:else}
+              <div class="mode-toggle">
+                <button
+                  class="mode-btn"
+                  class:mode-active={!pane.editMode}
+                  title="View Mode (Ctrl+E)"
+                  onclick={(e) => { e.stopPropagation(); if (pane.editMode) ontoggleedit?.(pane.id); }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                </button>
+                <button
+                  class="mode-btn"
+                  class:mode-active={pane.editMode}
+                  title="Edit Mode (Ctrl+E)"
+                  onclick={(e) => { e.stopPropagation(); if (!pane.editMode) ontoggleedit?.(pane.id); }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
+                </button>
+              </div>
+            {/if}
+            <button
+              class="close-btn"
+              title="Close pane (Ctrl+W)"
+              onclick={(e) => { e.stopPropagation(); onclosepane?.(pane.id); }}
+            >×</button>
+          </div>
         </header>
-        <MarkdownViewer
-          content={pane.content}
-          filePath={pane.path}
-          {layoutMode}
-          {onlayoutchange}
-          highlightText={pane.id === activePaneId ? highlightText : ""}
-          highlightKey={pane.id === activePaneId ? highlightKey : 0}
-        />
+        {#if pane.editMode}
+          <EditablePane
+            content={pane.content}
+            filePath={pane.path}
+            {onsave}
+            highlightText={pane.id === activePaneId ? highlightText : ""}
+            highlightKey={pane.id === activePaneId ? highlightKey : 0}
+          />
+        {:else}
+          <MarkdownViewer
+            content={pane.content}
+            filePath={pane.path}
+            {layoutMode}
+            {onlayoutchange}
+            highlightText={pane.id === activePaneId ? highlightText : ""}
+            highlightKey={pane.id === activePaneId ? highlightKey : 0}
+          />
+        {/if}
       </div>
     {/each}
   </div>
@@ -109,6 +148,58 @@
 
   .pane.active .pane-filename {
     color: #7aa2f7;
+  }
+
+  .pane-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
+  .mode-toggle {
+    display: flex;
+    border: 1px solid #2f3146;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .mode-btn {
+    background: none;
+    border: none;
+    color: #565f89;
+    cursor: pointer;
+    padding: 3px 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .mode-btn:first-child {
+    border-right: 1px solid #2f3146;
+  }
+
+  .mode-btn:hover {
+    color: #7aa2f7;
+    background: rgba(122, 162, 247, 0.1);
+  }
+
+  .mode-btn.mode-active {
+    color: #7aa2f7;
+    background: rgba(122, 162, 247, 0.15);
+  }
+
+  .read-only-badge {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #e0af68;
+    background: rgba(224, 175, 104, 0.12);
+    border: 1px solid rgba(224, 175, 104, 0.3);
+    border-radius: 4px;
+    padding: 2px 8px;
+    line-height: 1;
   }
 
   .close-btn {

--- a/src/lib/components/ContentArea.test.ts
+++ b/src/lib/components/ContentArea.test.ts
@@ -14,6 +14,58 @@ vi.mock("../services/filesystem", () => ({
   renderAsciiDiagram: vi.fn(),
 }));
 
+// Mock CodeMirror modules (needed by MarkdownEditor via EditablePane)
+vi.mock("@codemirror/view", () => ({
+  EditorView: Object.assign(
+    vi.fn().mockImplementation(function (this: any) {
+      this.destroy = vi.fn();
+      this.dispatch = vi.fn();
+    }),
+    {
+      updateListener: { of: vi.fn().mockReturnValue("updateListener") },
+      theme: vi.fn().mockReturnValue("customTheme"),
+      scrollIntoView: vi.fn().mockReturnValue({ type: "scrollIntoView" }),
+      decorations: { from: vi.fn().mockReturnValue("decorationsFrom") },
+    }
+  ),
+  Decoration: {
+    mark: vi.fn().mockReturnValue({ range: vi.fn().mockReturnValue({}) }),
+    set: vi.fn().mockReturnValue({}),
+    none: {},
+  },
+  keymap: { of: vi.fn().mockReturnValue("keymapExt") },
+  lineNumbers: vi.fn().mockReturnValue("lineNumbers"),
+  highlightActiveLine: vi.fn().mockReturnValue("highlightActiveLine"),
+  highlightActiveLineGutter: vi.fn().mockReturnValue("highlightActiveLineGutter"),
+}));
+
+vi.mock("@codemirror/state", () => ({
+  EditorState: {
+    create: vi.fn().mockImplementation((config: any) => ({
+      doc: config.doc,
+      extensions: config.extensions,
+    })),
+  },
+  StateField: {
+    define: vi.fn().mockReturnValue("searchHighlightField"),
+  },
+  StateEffect: {
+    define: vi.fn().mockReturnValue({ of: vi.fn().mockReturnValue({ type: "setSearchText" }) }),
+  },
+}));
+
+vi.mock("@codemirror/lang-markdown", () => ({
+  markdown: vi.fn().mockReturnValue("markdownLang"),
+}));
+
+vi.mock("@codemirror/theme-one-dark", () => ({
+  oneDark: "oneDarkTheme",
+}));
+
+vi.mock("codemirror", () => ({
+  basicSetup: "basicSetup",
+}));
+
 import ContentArea from "./ContentArea.svelte";
 import type { OpenPane, LayoutMode } from "../types";
 
@@ -83,10 +135,10 @@ describe("ContentArea", () => {
     });
 
     await vi.waitFor(() => {
-      expect(screen.getByTitle("Close pane")).toBeInTheDocument();
+      expect(screen.getByTitle("Close pane (Ctrl+W)")).toBeInTheDocument();
     });
 
-    await fireEvent.click(screen.getByTitle("Close pane"));
+    await fireEvent.click(screen.getByTitle("Close pane (Ctrl+W)"));
     expect(onclose).toHaveBeenCalledWith("1");
   });
 
@@ -133,5 +185,84 @@ describe("ContentArea", () => {
     const paneElements = document.querySelectorAll(".pane");
     await fireEvent.click(paneElements[1]);
     expect(onactivate).toHaveBeenCalledWith("2");
+  });
+
+  it("renders view and edit mode toggle buttons in pane header", async () => {
+    render(ContentArea, {
+      props: {
+        panes: [makePane("1", "/docs/readme.md", "# Hello")],
+        activePaneId: "1",
+        layoutMode: "centered" as LayoutMode,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByTitle("View Mode (Ctrl+E)")).toBeInTheDocument();
+      expect(screen.getByTitle("Edit Mode (Ctrl+E)")).toBeInTheDocument();
+    });
+  });
+
+  it("calls ontoggleedit when edit mode button is clicked", async () => {
+    const ontoggleedit = vi.fn();
+    render(ContentArea, {
+      props: {
+        panes: [makePane("1", "/docs/readme.md", "# Hello")],
+        activePaneId: "1",
+        layoutMode: "centered" as LayoutMode,
+        ontoggleedit,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByTitle("Edit Mode (Ctrl+E)")).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByTitle("Edit Mode (Ctrl+E)"));
+    expect(ontoggleedit).toHaveBeenCalledWith("1");
+  });
+
+  it("renders MarkdownViewer for pane in view mode", async () => {
+    render(ContentArea, {
+      props: {
+        panes: [makePane("1", "/docs/readme.md", "# Hello")],
+        activePaneId: "1",
+        layoutMode: "centered" as LayoutMode,
+      },
+    });
+
+    // In view mode, should NOT have editable-pane class
+    await vi.waitFor(() => {
+      expect(document.querySelector(".editable-pane")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows read-only badge and hides edit toggle for readOnly pane", async () => {
+    render(ContentArea, {
+      props: {
+        panes: [{ id: "1", path: "Help.md", content: "# Help", readOnly: true }],
+        activePaneId: "1",
+        layoutMode: "centered" as LayoutMode,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("Read Only")).toBeInTheDocument();
+      expect(screen.queryByTitle("Edit Mode (Ctrl+E)")).not.toBeInTheDocument();
+      expect(screen.queryByTitle("View Mode (Ctrl+E)")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders EditablePane for pane in edit mode", async () => {
+    render(ContentArea, {
+      props: {
+        panes: [{ id: "1", path: "/docs/readme.md", content: "# Hello", editMode: true }],
+        activePaneId: "1",
+        layoutMode: "centered" as LayoutMode,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(document.querySelector(".editable-pane")).toBeInTheDocument();
+    });
   });
 });

--- a/src/lib/components/EditablePane.svelte
+++ b/src/lib/components/EditablePane.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import MarkdownEditor from "./MarkdownEditor.svelte";
+  import MarkdownViewer from "./MarkdownViewer.svelte";
+
+  let {
+    content = "",
+    filePath = "",
+    onsave,
+    highlightText = "",
+    highlightKey = 0,
+  }: {
+    content?: string;
+    filePath?: string;
+    onsave?: (path: string, content: string) => void;
+    highlightText?: string;
+    highlightKey?: number;
+  } = $props();
+
+  let editContent = $state(content);
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  let activeLineDebounce: ReturnType<typeof setTimeout> | undefined;
+  let activeLineText = $state("");
+  let activeLineNumber = $state(1);
+  let activeTotalLines = $state(1);
+  let activeColumn = $state(1);
+  let paneEl: HTMLDivElement | undefined = $state();
+
+  // Scroll wheel sync between editor and preview
+  let syncing = false;
+  let cleanupScrollSync: (() => void) | undefined;
+
+  function setupScrollSync() {
+    cleanupScrollSync?.();
+    if (!paneEl) return;
+
+    const editorScroller = paneEl.querySelector('.cm-scroller') as HTMLElement | null;
+    const previewScroller = paneEl.querySelector('.markdown-body') as HTMLElement | null;
+    if (!editorScroller || !previewScroller) return;
+
+    function syncScroll(source: HTMLElement, target: HTMLElement) {
+      if (syncing) return;
+      const maxSource = source.scrollHeight - source.clientHeight;
+      const maxTarget = target.scrollHeight - target.clientHeight;
+      if (maxSource <= 0 || maxTarget <= 0) return;
+      const ratio = source.scrollTop / maxSource;
+      syncing = true;
+      target.scrollTop = ratio * maxTarget;
+      requestAnimationFrame(() => { syncing = false; });
+    }
+
+    function onEditorScroll() { syncScroll(editorScroller!, previewScroller!); }
+    function onPreviewScroll() { syncScroll(previewScroller!, editorScroller!); }
+
+    editorScroller.addEventListener('scroll', onEditorScroll);
+    previewScroller.addEventListener('scroll', onPreviewScroll);
+
+    cleanupScrollSync = () => {
+      editorScroller.removeEventListener('scroll', onEditorScroll);
+      previewScroller.removeEventListener('scroll', onPreviewScroll);
+    };
+  }
+
+  // Set up scroll sync after mount and whenever content changes (DOM may rebuild)
+  onMount(() => {
+    // Delay slightly to let CodeMirror mount its .cm-scroller
+    const timer = setTimeout(setupScrollSync, 100);
+    return () => clearTimeout(timer);
+  });
+
+  $effect(() => {
+    // Re-setup when editContent changes (preview re-renders)
+    const _content = editContent;
+    // Small delay to let DOM update
+    const timer = setTimeout(setupScrollSync, 100);
+    return () => clearTimeout(timer);
+  });
+
+  onDestroy(() => {
+    cleanupScrollSync?.();
+  });
+
+  // When the file changes (navigation), sync editContent from the new prop value
+  $effect(() => {
+    filePath;
+    editContent = content;
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = undefined;
+    }
+  });
+
+  function handleEdit(newContent: string) {
+    editContent = newContent;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      onsave?.(filePath, editContent);
+    }, 1000);
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (event.ctrlKey && event.key === "s") {
+      event.preventDefault();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      onsave?.(filePath, editContent);
+    }
+  }
+
+  function handleActiveLine(lineContent: string, lineNumber: number, totalLines: number, column: number) {
+    if (activeLineDebounce) clearTimeout(activeLineDebounce);
+    activeLineDebounce = setTimeout(() => {
+      activeLineText = lineContent;
+      activeLineNumber = lineNumber;
+      activeTotalLines = totalLines;
+      activeColumn = column;
+    }, 50);
+  }
+
+  const fileName = $derived(filePath ? filePath.split(/[\\/]/).pop() ?? "" : "");
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="editable-pane" onkeydown={handleKeyDown} bind:this={paneEl}>
+  <div class="editor-side">
+    <header class="editor-header">
+      <span class="editor-label">Editor</span>
+      <span class="cursor-pos">Ln {activeLineNumber}, Col {activeColumn}</span>
+    </header>
+    <div class="editor-content">
+      <MarkdownEditor content={editContent} onchange={handleEdit} {highlightText} {highlightKey} onactiveline={handleActiveLine} />
+    </div>
+  </div>
+  <div class="preview-side">
+    <header class="preview-header">
+      <span class="preview-label">Preview</span>
+      <span class="preview-file" title={filePath}>{fileName}</span>
+    </header>
+    <MarkdownViewer content={editContent} {filePath} {highlightText} {highlightKey} {activeLineText} {activeLineNumber} {activeTotalLines} {activeColumn} showHeader={false} />
+  </div>
+</div>
+
+<style>
+  .editable-pane {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .editor-side {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-right: 1px solid #2f3146;
+  }
+
+  .editor-header {
+    padding: 6px 12px;
+    border-bottom: 1px solid #2f3146;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #1e1f2e;
+    min-height: 32px;
+  }
+
+  .editor-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #7aa2f7;
+  }
+
+  .cursor-pos {
+    font-size: 11px;
+    color: #565f89;
+    font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", monospace;
+  }
+
+  .editor-content {
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .preview-side {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .preview-header {
+    padding: 6px 12px;
+    border-bottom: 1px solid #2f3146;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #1e1f2e;
+    min-height: 32px;
+  }
+
+  .preview-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #9ece6a;
+  }
+
+  .preview-file {
+    font-size: 11px;
+    color: #565f89;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/components/EditablePane.test.ts
+++ b/src/lib/components/EditablePane.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+
+// Mock mermaid (needed by MarkdownViewer)
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    run: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Mock filesystem (needed by MarkdownViewer for renderAsciiDiagram)
+vi.mock("../services/filesystem", () => ({
+  renderAsciiDiagram: vi.fn(),
+}));
+
+// Mock CodeMirror modules (needed by MarkdownEditor)
+vi.mock("@codemirror/view", () => ({
+  EditorView: Object.assign(
+    vi.fn().mockImplementation(function (this: any) {
+      this.destroy = vi.fn();
+      this.dispatch = vi.fn();
+    }),
+    {
+      updateListener: { of: vi.fn().mockReturnValue("updateListener") },
+      theme: vi.fn().mockReturnValue("customTheme"),
+      scrollIntoView: vi.fn().mockReturnValue({ type: "scrollIntoView" }),
+      decorations: { from: vi.fn().mockReturnValue("decorationsFrom") },
+    }
+  ),
+  Decoration: {
+    mark: vi.fn().mockReturnValue({ range: vi.fn().mockReturnValue({}) }),
+    set: vi.fn().mockReturnValue({}),
+    none: {},
+  },
+  keymap: { of: vi.fn().mockReturnValue("keymapExt") },
+  lineNumbers: vi.fn().mockReturnValue("lineNumbers"),
+  highlightActiveLine: vi.fn().mockReturnValue("highlightActiveLine"),
+  highlightActiveLineGutter: vi.fn().mockReturnValue("highlightActiveLineGutter"),
+}));
+
+vi.mock("@codemirror/state", () => ({
+  EditorState: {
+    create: vi.fn().mockImplementation((config: any) => ({
+      doc: config.doc,
+      extensions: config.extensions,
+    })),
+  },
+  StateField: {
+    define: vi.fn().mockReturnValue("searchHighlightField"),
+  },
+  StateEffect: {
+    define: vi.fn().mockReturnValue({ of: vi.fn().mockReturnValue({ type: "setSearchText" }) }),
+  },
+}));
+
+vi.mock("@codemirror/lang-markdown", () => ({
+  markdown: vi.fn().mockReturnValue("markdownLang"),
+}));
+
+vi.mock("@codemirror/theme-one-dark", () => ({
+  oneDark: "oneDarkTheme",
+}));
+
+vi.mock("codemirror", () => ({
+  basicSetup: "basicSetup",
+}));
+
+import EditablePane from "./EditablePane.svelte";
+
+describe("EditablePane", () => {
+  it("renders with split-pane layout", () => {
+    render(EditablePane, {
+      props: {
+        content: "# Hello",
+        filePath: "/docs/test.md",
+        onsave: vi.fn(),
+      },
+    });
+
+    expect(document.querySelector(".editable-pane")).toBeInTheDocument();
+    expect(document.querySelector(".editor-side")).toBeInTheDocument();
+    expect(document.querySelector(".preview-side")).toBeInTheDocument();
+  });
+
+  it("renders editor and preview side by side", () => {
+    render(EditablePane, {
+      props: {
+        content: "# Hello",
+        filePath: "/docs/test.md",
+        onsave: vi.fn(),
+      },
+    });
+
+    const editorSide = document.querySelector(".editor-side");
+    const previewSide = document.querySelector(".preview-side");
+    expect(editorSide).toBeInTheDocument();
+    expect(previewSide).toBeInTheDocument();
+  });
+
+  it("passes filePath to preview side", () => {
+    const { container } = render(EditablePane, {
+      props: {
+        content: "# Hello",
+        filePath: "/docs/test.md",
+        onsave: vi.fn(),
+      },
+    });
+
+    const previewSide = container.querySelector(".preview-side");
+    expect(previewSide).toBeInTheDocument();
+  });
+
+  it("calls onsave with Ctrl+S", async () => {
+    const onsave = vi.fn();
+    render(EditablePane, {
+      props: {
+        content: "# Hello",
+        filePath: "/docs/test.md",
+        onsave,
+      },
+    });
+
+    const pane = document.querySelector(".editable-pane")!;
+    await fireEvent.keyDown(pane, { key: "s", ctrlKey: true });
+
+    expect(onsave).toHaveBeenCalledWith("/docs/test.md", "# Hello");
+  });
+
+  it("does not auto-save immediately without changes", () => {
+    const onsave = vi.fn();
+    render(EditablePane, {
+      props: {
+        content: "# Hello",
+        filePath: "/docs/test.md",
+        onsave,
+      },
+    });
+
+    // Without any content change, onsave should not be called
+    expect(onsave).not.toHaveBeenCalled();
+  });
+
+  describe("scroll wheel sync", () => {
+    it("has editor and preview containers for scroll sync", () => {
+      render(EditablePane, {
+        props: {
+          content: "# Hello\n\nSome text",
+          filePath: "/docs/test.md",
+          onsave: vi.fn(),
+        },
+      });
+
+      const editorSide = document.querySelector(".editor-side");
+      const previewSide = document.querySelector(".preview-side");
+      expect(editorSide).toBeInTheDocument();
+      expect(previewSide).toBeInTheDocument();
+
+      // Preview side should contain a scrollable markdown-body element
+      const viewer = previewSide?.querySelector(".viewer");
+      expect(viewer).toBeInTheDocument();
+    });
+
+    it("syncs preview scroll when editor receives wheel event", async () => {
+      render(EditablePane, {
+        props: {
+          content: "# Hello\n\nLong content\n".repeat(50),
+          filePath: "/docs/test.md",
+          onsave: vi.fn(),
+        },
+      });
+
+      const editorContent = document.querySelector(".editor-content");
+      expect(editorContent).toBeInTheDocument();
+
+      // Fire a wheel event on the editor content area
+      await fireEvent.wheel(editorContent!, { deltaY: 100 });
+
+      // The scroll sync mechanism should exist (no errors thrown)
+      // Actual scroll sync requires real DOM scroll containers
+      const previewSide = document.querySelector(".preview-side");
+      expect(previewSide).toBeInTheDocument();
+    });
+
+    it("syncs editor scroll when preview receives wheel event", async () => {
+      render(EditablePane, {
+        props: {
+          content: "# Hello\n\nLong content\n".repeat(50),
+          filePath: "/docs/test.md",
+          onsave: vi.fn(),
+        },
+      });
+
+      const previewSide = document.querySelector(".preview-side");
+      expect(previewSide).toBeInTheDocument();
+
+      // Fire a wheel event on the preview side
+      await fireEvent.wheel(previewSide!, { deltaY: 100 });
+
+      // The scroll sync mechanism should exist (no errors thrown)
+      const editorContent = document.querySelector(".editor-content");
+      expect(editorContent).toBeInTheDocument();
+    });
+  });
+});

--- a/src/lib/components/MarkdownEditor.svelte
+++ b/src/lib/components/MarkdownEditor.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { EditorView, Decoration, type DecorationSet } from "@codemirror/view";
+  import { EditorState, StateField, StateEffect } from "@codemirror/state";
+  import { markdown } from "@codemirror/lang-markdown";
+  import { oneDark } from "@codemirror/theme-one-dark";
+  import { basicSetup } from "codemirror";
+
+  let {
+    content = "",
+    onchange,
+    highlightText = "",
+    highlightKey = 0,
+    onactiveline,
+  }: {
+    content?: string;
+    onchange?: (content: string) => void;
+    highlightText?: string;
+    highlightKey?: number;
+    onactiveline?: (lineContent: string, lineNumber: number, totalLines: number, column: number) => void;
+  } = $props();
+
+  let containerEl: HTMLDivElement | undefined = $state();
+  let view: EditorView | undefined;
+  let suppressNextChange = false;
+
+  // Search highlight via CodeMirror decorations
+  const setSearchText = StateEffect.define<string>();
+  const searchMark = Decoration.mark({ class: "cm-search-highlight" });
+
+  function computeSearchDecorations(state: EditorState, text: string): DecorationSet {
+    if (!text.trim()) return Decoration.none;
+    const trimmed = text.trim();
+    const ranges: ReturnType<typeof searchMark.range>[] = [];
+    for (let i = 1; i <= state.doc.lines; i++) {
+      const line = state.doc.line(i);
+      let pos = 0;
+      while (pos < line.text.length) {
+        const idx = line.text.indexOf(trimmed, pos);
+        if (idx === -1) break;
+        ranges.push(searchMark.range(line.from + idx, line.from + idx + trimmed.length));
+        pos = idx + trimmed.length;
+      }
+    }
+    return Decoration.set(ranges, true);
+  }
+
+  const searchHighlightField = StateField.define<{ text: string; decorations: DecorationSet }>({
+    create() {
+      return { text: "", decorations: Decoration.none };
+    },
+    update(value, tr) {
+      let text = value.text;
+      for (const e of tr.effects) {
+        if (e.is(setSearchText)) {
+          text = e.value;
+        }
+      }
+      if (text !== value.text || (tr.docChanged && text)) {
+        return { text, decorations: computeSearchDecorations(tr.state, text) };
+      }
+      return value;
+    },
+    provide: (f) => EditorView.decorations.from(f, (v) => v.decorations),
+  });
+
+  onMount(() => {
+    if (!containerEl) return;
+
+    const state = EditorState.create({
+      doc: content,
+      extensions: [
+        basicSetup,
+        markdown(),
+        oneDark,
+        searchHighlightField,
+        EditorView.theme({
+          "&": { height: "100%", fontSize: "14px" },
+          ".cm-scroller": { overflow: "auto" },
+          ".cm-content": { fontFamily: "'JetBrains Mono', 'Fira Code', monospace" },
+          ".cm-search-highlight": { backgroundColor: "rgba(224, 175, 104, 0.35)", borderRadius: "2px" },
+          ".cm-activeLine": { backgroundColor: "rgba(122, 162, 247, 0.08) !important" },
+        }),
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            if (suppressNextChange) {
+              suppressNextChange = false;
+              return;
+            }
+            onchange?.(update.state.doc.toString());
+          }
+          // Emit active line content, number, total, and column on cursor movement or doc change
+          if ((update.selectionSet || update.docChanged) && update.state.selection) {
+            const cursor = update.state.selection.main.head;
+            const line = update.state.doc.lineAt(cursor);
+            onactiveline?.(line.text, line.number, update.state.doc.lines, cursor - line.from + 1);
+          }
+        }),
+      ],
+    });
+
+    view = new EditorView({
+      state,
+      parent: containerEl,
+    });
+
+  });
+
+  // If the content prop changes externally (e.g. initial load timing), sync the editor
+  $effect(() => {
+    if (!view?.state?.doc) return;
+    const currentDoc = view.state.doc.toString();
+    if (content !== currentDoc) {
+      suppressNextChange = true;
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: content },
+      });
+    }
+  });
+
+  // When search highlight text changes, update CodeMirror decorations and scroll to match
+  // NOTE: `content` is tracked so that when a new file loads (content changes)
+  // while highlightText is already set, the search re-fires and scrolls to the match.
+  $effect(() => {
+    if (!view) return;
+    const text = highlightText;
+    const _key = highlightKey;
+    const _content = content;
+
+    const effects: any[] = [setSearchText.of(text)];
+
+    if (text.trim()) {
+      const trimmed = text.trim();
+      const doc = view.state.doc;
+      for (let i = 1; i <= doc.lines; i++) {
+        const line = doc.line(i);
+        const idx = line.text.indexOf(trimmed);
+        if (idx !== -1) {
+          effects.push(EditorView.scrollIntoView(line.from + idx, { y: "center" }));
+          break;
+        }
+      }
+    }
+
+    view.dispatch({ effects });
+  });
+
+  onDestroy(() => {
+    view?.destroy();
+  });
+</script>
+
+<div class="markdown-editor" bind:this={containerEl}></div>
+
+<style>
+  .markdown-editor {
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .markdown-editor :global(.cm-editor) {
+    height: 100%;
+  }
+</style>

--- a/src/lib/components/MarkdownEditor.test.ts
+++ b/src/lib/components/MarkdownEditor.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+
+// Use vi.hoisted so mock functions are available when vi.mock runs (hoisted above imports)
+const {
+  mockDestroy,
+  mockDispatch,
+  MockEditorView,
+  mockUpdateListenerOf,
+  captured,
+} = vi.hoisted(() => {
+  const mockDestroy = vi.fn();
+  const mockDispatch = vi.fn();
+  const captured: {
+    parent?: HTMLElement;
+    updateListener?: (update: any) => void;
+    doc?: string;
+  } = {};
+
+  // Must use regular function (not arrow) so it can be called with `new`
+  const MockEditorView = vi.fn().mockImplementation(function (this: any, config: any) {
+    captured.parent = config.parent;
+    captured.doc = config.state?.doc;
+    this.destroy = mockDestroy;
+    this.dispatch = mockDispatch;
+  });
+
+  const mockUpdateListenerOf = vi.fn().mockImplementation((cb: any) => {
+    captured.updateListener = cb;
+    return "updateListener";
+  });
+
+  return { mockDestroy, mockDispatch, MockEditorView, mockUpdateListenerOf, captured };
+});
+
+vi.mock("@codemirror/view", () => ({
+  EditorView: Object.assign(MockEditorView, {
+    updateListener: { of: mockUpdateListenerOf },
+    theme: vi.fn().mockReturnValue("customTheme"),
+    scrollIntoView: vi.fn().mockReturnValue({ type: "scrollIntoView" }),
+    decorations: { from: vi.fn().mockReturnValue("decorationsFrom") },
+  }),
+  Decoration: {
+    mark: vi.fn().mockReturnValue({ range: vi.fn().mockReturnValue({}) }),
+    set: vi.fn().mockReturnValue({}),
+    none: {},
+  },
+  keymap: { of: vi.fn().mockReturnValue("keymapExt") },
+  lineNumbers: vi.fn().mockReturnValue("lineNumbers"),
+  highlightActiveLine: vi.fn().mockReturnValue("highlightActiveLine"),
+  highlightActiveLineGutter: vi.fn().mockReturnValue("highlightActiveLineGutter"),
+}));
+
+vi.mock("@codemirror/state", () => ({
+  EditorState: {
+    create: vi.fn().mockImplementation((config: any) => ({
+      doc: config.doc,
+      extensions: config.extensions,
+    })),
+  },
+  StateField: {
+    define: vi.fn().mockReturnValue("searchHighlightField"),
+  },
+  StateEffect: {
+    define: vi.fn().mockReturnValue({ of: vi.fn().mockReturnValue({ type: "setSearchText" }) }),
+  },
+}));
+
+vi.mock("@codemirror/lang-markdown", () => ({
+  markdown: vi.fn().mockReturnValue("markdownLang"),
+}));
+
+vi.mock("@codemirror/theme-one-dark", () => ({
+  oneDark: "oneDarkTheme",
+}));
+
+vi.mock("codemirror", () => ({
+  basicSetup: "basicSetup",
+}));
+
+import MarkdownEditor from "./MarkdownEditor.svelte";
+
+beforeEach(() => {
+  MockEditorView.mockClear();
+  mockDestroy.mockClear();
+  mockDispatch.mockClear();
+  mockUpdateListenerOf.mockClear();
+  captured.parent = undefined;
+  captured.updateListener = undefined;
+  captured.doc = undefined;
+});
+
+describe("MarkdownEditor", () => {
+  it("renders an editor container element", () => {
+    render(MarkdownEditor, {
+      props: { content: "# Hello", onchange: vi.fn() },
+    });
+
+    expect(document.querySelector(".markdown-editor")).toBeInTheDocument();
+  });
+
+  it("creates EditorView with provided content", async () => {
+    render(MarkdownEditor, {
+      props: { content: "# Test Content", onchange: vi.fn() },
+    });
+
+    await vi.waitFor(() => {
+      expect(MockEditorView).toHaveBeenCalled();
+      expect(captured.doc).toBe("# Test Content");
+    });
+  });
+
+  it("calls onchange when document changes", async () => {
+    const onchange = vi.fn();
+    render(MarkdownEditor, {
+      props: { content: "# Hello", onchange },
+    });
+
+    await vi.waitFor(() => {
+      expect(captured.updateListener).toBeDefined();
+    });
+
+    // Simulate a document change via the updateListener
+    captured.updateListener!({
+      docChanged: true,
+      state: { doc: { toString: () => "# Updated" } },
+    });
+
+    expect(onchange).toHaveBeenCalledWith("# Updated");
+  });
+
+  it("does not call onchange when document has not changed", async () => {
+    const onchange = vi.fn();
+    render(MarkdownEditor, {
+      props: { content: "# Hello", onchange },
+    });
+
+    await vi.waitFor(() => {
+      expect(captured.updateListener).toBeDefined();
+    });
+
+    // Simulate a non-document update (e.g., selection change)
+    captured.updateListener!({
+      docChanged: false,
+      state: { doc: { toString: () => "# Hello" } },
+    });
+
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it("re-dispatches search highlight when content changes while highlightText is set", async () => {
+    // Scenario: user clicks a search result for a NEW file.
+    // highlightText is set synchronously, but content loads async.
+    // The search effect must re-fire when content arrives.
+
+    // Mock doc that starts empty and gets updated when "file loads"
+    let docContent = "";
+    let docLines = 0;
+    const mockDoc = {
+      get lines() { return docLines; },
+      line: vi.fn().mockImplementation(() => ({ from: 0, text: "" })),
+      lineAt: vi.fn().mockReturnValue({ text: "", number: 1, from: 0 }),
+      toString: () => docContent,
+      get length() { return docContent.length; },
+    };
+
+    const originalImpl = MockEditorView.getMockImplementation();
+    MockEditorView.mockImplementation(function (this: any, config: any) {
+      captured.parent = config.parent;
+      captured.doc = config.state?.doc;
+      this.destroy = mockDestroy;
+      this.dispatch = mockDispatch;
+      this.state = { doc: mockDoc };
+    });
+
+    // Render with empty content but active search text
+    const { rerender } = render(MarkdownEditor, {
+      props: { content: "", highlightText: "hello", highlightKey: 1 },
+    });
+
+    await vi.waitFor(() => expect(MockEditorView).toHaveBeenCalledTimes(1));
+
+    // Initial: doc is empty → search dispatches setSearchText but no scrollIntoView
+    const initialScrolls = mockDispatch.mock.calls.filter(
+      (c: any) => c[0]?.effects?.some?.((e: any) => e.type === "scrollIntoView")
+    );
+    expect(initialScrolls.length).toBe(0);
+
+    // Clear and prepare for "file load"
+    mockDispatch.mockClear();
+    mockDestroy.mockClear();
+
+    // Update mock doc to contain the search text
+    docContent = "line with hello world";
+    docLines = 1;
+    mockDoc.line = vi.fn().mockReturnValue({ from: 0, text: "line with hello world" });
+    mockDoc.lineAt = vi.fn().mockReturnValue({ text: "line with hello world", number: 1, from: 0 });
+
+    // Rerender with new content (same highlightText & highlightKey)
+    await rerender({ content: "line with hello world", highlightText: "hello", highlightKey: 1 });
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Check if rerender remounted the component
+    const remounted = mockDestroy.mock.calls.length > 0;
+
+    // Verify scrollIntoView was dispatched after content change
+    const hasScroll = mockDispatch.mock.calls.some(
+      (c: any) => c[0]?.effects?.some?.((e: any) => e.type === "scrollIntoView")
+    );
+
+    if (!remounted) {
+      // True prop-update test: search effect must track content
+      expect(hasScroll).toBe(true);
+    } else {
+      // Remount: effects run fresh with full props — always finds match
+      expect(hasScroll).toBe(true);
+    }
+
+    if (originalImpl) MockEditorView.mockImplementation(originalImpl);
+  });
+});

--- a/src/lib/components/MarkdownViewer.svelte
+++ b/src/lib/components/MarkdownViewer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { renderMarkdown, renderMermaidDiagrams, renderBobDiagrams } from "../services/markdown";
-  import { extractDiagramLabels, getCodeBlockLineOverlayPosition } from "../services/highlight";
+  import { extractDiagramLabels, getCodeBlockLineOverlayPosition, stripMarkdownSyntax, findMatchingBlockElement, findMatchingPreElement, clearBlockHighlights, getTableCellIndex } from "../services/highlight";
   import type { LayoutMode } from "../types";
 
   let {
@@ -10,6 +10,11 @@
     onlayoutchange,
     highlightText = "",
     highlightKey = 0,
+    activeLineText = "",
+    activeLineNumber = 1,
+    activeTotalLines = 1,
+    activeColumn = 1,
+    showHeader = true,
   }: {
     content?: string;
     filePath?: string;
@@ -17,11 +22,19 @@
     onlayoutchange?: (mode: LayoutMode) => void;
     highlightText?: string;
     highlightKey?: number;
+    activeLineText?: string;
+    activeLineNumber?: number;
+    activeTotalLines?: number;
+    activeColumn?: number;
+    showHeader?: boolean;
   } = $props();
 
   let htmlContent = $state("");
   let articleEl: HTMLElement | undefined = $state();
   let diagramsReady = $state(0);
+  let imagesReady = $state(0);
+  // Timestamp of last search-driven scroll — active line scroll is suppressed briefly after
+  let lastSearchScrollTime = 0;
 
   $effect(() => {
     if (content) {
@@ -50,6 +63,34 @@
     }
   });
 
+  // After HTML updates, watch for image loads that cause layout shifts
+  $effect(() => {
+    const el = articleEl;
+    const _html = htmlContent;
+    if (!el || !_html) return;
+
+    const images = el.querySelectorAll('img');
+    if (images.length === 0) return;
+
+    const onLoad = () => { imagesReady++; };
+
+    const pending: HTMLImageElement[] = [];
+    images.forEach(img => {
+      if (!img.complete) {
+        img.addEventListener('load', onLoad, { once: true });
+        img.addEventListener('error', onLoad, { once: true });
+        pending.push(img);
+      }
+    });
+
+    return () => {
+      pending.forEach(img => {
+        img.removeEventListener('load', onLoad);
+        img.removeEventListener('error', onLoad);
+      });
+    };
+  });
+
   // Highlight and scroll to matching text from search results
   $effect(() => {
     const text = highlightText;
@@ -57,6 +98,7 @@
     const _key = highlightKey; // depend on key to re-fire on repeated clicks
     const _html = htmlContent; // re-fire when content renders
     const _ready = diagramsReady; // re-fire after diagrams finish rendering
+    const _images = imagesReady; // re-fire when images load (layout shift)
     if (!text || !el || !_html) return;
 
     // Wait for DOM to be updated with the new content
@@ -81,6 +123,8 @@
     container.querySelectorAll(".search-highlight-line").forEach((el) => {
       el.classList.remove("search-highlight-line");
     });
+    // Remove block-level highlights
+    clearBlockHighlights(container, "search-highlight-block");
     // Remove line overlays
     container.querySelectorAll(".search-line-overlay").forEach((el) => {
       el.remove();
@@ -94,13 +138,24 @@
     if (!trimmedText) return;
 
     // Strategy 1: Exact text node match (paragraphs, headings, plain text)
-    if (tryTextNodeHighlight(container, trimmedText)) return;
+    if (tryTextNodeHighlight(container, trimmedText)) { lastSearchScrollTime = Date.now(); return; }
+
+    // Strategy 1b: Strip markdown syntax and try text node match again
+    const stripped = stripMarkdownSyntax(trimmedText);
+    if (stripped !== trimmedText && stripped.length >= 2) {
+      if (tryTextNodeHighlight(container, stripped)) { lastSearchScrollTime = Date.now(); return; }
+    }
+
+    // Strategy 1c: Block-level fallback — highlight the entire block element
+    if (stripped.length >= 2) {
+      if (tryBlockHighlight(container, stripped)) { lastSearchScrollTime = Date.now(); return; }
+    }
 
     // Strategy 2: Code block line highlight (syntax-highlighted code)
-    if (tryCodeBlockLineHighlight(container, trimmedText)) return;
+    if (tryCodeBlockLineHighlight(container, trimmedText)) { lastSearchScrollTime = Date.now(); return; }
 
     // Strategy 3: SVG/diagram container (svgbob, mermaid — original text gone)
-    if (tryDiagramContainerHighlight(container, trimmedText)) return;
+    if (tryDiagramContainerHighlight(container, trimmedText)) { lastSearchScrollTime = Date.now(); return; }
   }
 
   function tryTextNodeHighlight(container: HTMLElement, text: string): boolean {
@@ -126,6 +181,14 @@
       return true;
     }
     return false;
+  }
+
+  function tryBlockHighlight(container: HTMLElement, text: string): boolean {
+    const block = findMatchingBlockElement(container, text);
+    if (!block) return false;
+    block.classList.add("search-highlight-block");
+    block.scrollIntoView({ behavior: "smooth", block: "center" });
+    return true;
   }
 
   function tryCodeBlockLineHighlight(container: HTMLElement, text: string): boolean {
@@ -214,18 +277,99 @@
     return false;
   }
 
+  // Active line highlight: show which editor line corresponds to the preview
+  $effect(() => {
+    const text = activeLineText;
+    const lineNum = activeLineNumber;
+    const totalLines = activeTotalLines;
+    const col = activeColumn;
+    const el = articleEl;
+    const _html = htmlContent;
+    if (!el) return;
+
+    const frame = requestAnimationFrame(() => {
+      // Clear previous highlights and overlays
+      clearBlockHighlights(el, "active-line-block");
+      el.querySelectorAll(".active-line-overlay").forEach(o => o.remove());
+
+      if (!text.trim()) return;
+
+      // Don't scroll if a search highlight just happened (prevents fighting)
+      const shouldScroll = Date.now() - lastSearchScrollTime > 500;
+
+      // Calculate position ratio for disambiguation (0 = top, 1 = bottom)
+      const positionRatio = totalLines > 1 ? (lineNum - 1) / (totalLines - 1) : 0;
+
+      const stripped = stripMarkdownSyntax(text);
+
+      // Determine table cell index from cursor column (for table row lines)
+      const cellIndex = getTableCellIndex(text, col);
+
+      // Strategy 1: Match normal block elements (p, h1-h6, li, td, th, etc.)
+      // Uses positionRatio to pick the correct match when text appears multiple times
+      // For table rows, cellIndex targets the specific cell under the cursor
+      if (stripped.length >= 2) {
+        const block = findMatchingBlockElement(el, stripped, positionRatio, cellIndex >= 0 ? cellIndex : undefined);
+        if (block) {
+          block.classList.add("active-line-block");
+          if (shouldScroll) {
+            block.scrollIntoView({ behavior: "instant", block: "center" });
+          }
+          return;
+        }
+      }
+
+      // Strategy 2: Match code blocks and diagrams by raw line text
+      // Highlights the specific LINE within the code block, not the whole block
+      const rawTrimmed = text.trim();
+      if (rawTrimmed.length >= 2) {
+        const pre = findMatchingPreElement(el, rawTrimmed);
+        if (pre) {
+          // Try to highlight just the matching line within the code block
+          const pos = getCodeBlockLineOverlayPosition(pre as HTMLElement, rawTrimmed);
+          if (pos) {
+            pre.style.position = "relative";
+            const overlay = document.createElement("div");
+            overlay.className = "active-line-overlay";
+            overlay.style.position = "absolute";
+            overlay.style.left = "0";
+            overlay.style.right = "0";
+            overlay.style.top = `${pos.top}px`;
+            overlay.style.height = `${pos.height}px`;
+            overlay.style.pointerEvents = "none";
+            pre.appendChild(overlay);
+            if (shouldScroll) {
+              overlay.scrollIntoView({ behavior: "instant", block: "center" });
+            }
+          } else {
+            // Fallback: highlight entire block (e.g. mermaid where text is in SVG)
+            pre.classList.add("active-line-block");
+            if (shouldScroll) {
+              pre.scrollIntoView({ behavior: "instant", block: "center" });
+            }
+          }
+          return;
+        }
+      }
+    });
+
+    return () => cancelAnimationFrame(frame);
+  });
+
   const fileName = $derived(filePath ? filePath.split(/[\\/]/).pop() ?? "" : "");
 </script>
 
 <div class="viewer" role="main" aria-label="Markdown viewer">
   {#if content}
-    <header class="viewer-header">
-      <span class="file-name" title={filePath}>{fileName}</span>
-      <div class="layout-controls">
-        <button class:active={layoutMode === "centered"} onclick={() => onlayoutchange?.("centered")} title="Single column">&#x2261;</button>
-        <button class:active={layoutMode === "columns"} onclick={() => onlayoutchange?.("columns")} title="Multi-column">&#x229E;</button>
-      </div>
-    </header>
+    {#if showHeader}
+      <header class="viewer-header">
+        <span class="file-name" title={filePath}>{fileName}</span>
+        <div class="layout-controls">
+          <button class:active={layoutMode === "centered"} onclick={() => onlayoutchange?.("centered")} title="Single column">&#x2261;</button>
+          <button class:active={layoutMode === "columns"} onclick={() => onlayoutchange?.("columns")} title="Multi-column">&#x229E;</button>
+        </div>
+      </header>
+    {/if}
     <article class="markdown-body" class:centered={layoutMode === "centered"} class:columns={layoutMode === "columns"} bind:this={articleEl}>
       {@html htmlContent}
     </article>

--- a/src/lib/components/MarkdownViewer.test.ts
+++ b/src/lib/components/MarkdownViewer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/svelte";
 
 // Mock mermaid
@@ -7,6 +7,12 @@ vi.mock("mermaid", () => ({
     initialize: vi.fn(),
     run: vi.fn().mockResolvedValue(undefined),
   },
+}));
+
+// Mock Tauri API (needed for image resolution in markdown renderer)
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: vi.fn((path: string) => `asset://localhost/${path}`),
+  invoke: vi.fn(),
 }));
 
 import MarkdownViewer from "./MarkdownViewer.svelte";
@@ -86,6 +92,89 @@ describe("MarkdownViewer", () => {
     await vi.waitFor(() => {
       expect(screen.getByTitle("Single column")).toBeInTheDocument();
       expect(screen.getByTitle("Multi-column")).toBeInTheDocument();
+    });
+  });
+
+  describe("image layout shift fix", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    it("re-scrolls search highlight after images load", async () => {
+      // Render with content containing an image and searchable text below it
+      const contentWithImage = "![photo](test.png)\n\n# Target Heading";
+
+      const { container } = render(MarkdownViewer, {
+        props: {
+          content: contentWithImage,
+          filePath: "/docs/test.md",
+          highlightText: "Target Heading",
+          highlightKey: 1,
+        },
+      });
+
+      // Wait for markdown to render
+      await vi.waitFor(() => {
+        const article = container.querySelector("article.markdown-body");
+        expect(article).not.toBeNull();
+        expect(article!.innerHTML).toContain("img");
+      });
+
+      // Spy on scrollIntoView to track re-scroll calls
+      const scrollSpy = vi.fn();
+
+      // Wait for the initial search highlight to happen
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Find the image and simulate its load event (layout shift trigger)
+      const img = container.querySelector("img") as HTMLImageElement;
+      expect(img).not.toBeNull();
+
+      // Mock img.complete = false to ensure the load listener is attached
+      Object.defineProperty(img, "complete", { value: false, writable: true });
+
+      // The search effect should have added a load listener.
+      // Verify that firing load on the image causes a re-scroll.
+      // We track this by checking that scrollIntoView is called on a mark element
+      const markEl = container.querySelector("mark.search-highlight");
+      if (markEl) {
+        markEl.scrollIntoView = scrollSpy;
+      }
+
+      // Fire the image load event
+      img.dispatchEvent(new Event("load"));
+
+      // Allow the effect to re-run after imagesReady increments
+      await vi.advanceTimersByTimeAsync(100);
+
+      // The search effect should have re-fired after image load,
+      // causing a new scrollIntoView on the highlighted element
+      // (the mark gets recreated each time, so we check any mark)
+      const marks = container.querySelectorAll("mark.search-highlight");
+      expect(marks.length).toBeGreaterThan(0);
+    });
+
+    it("attaches load listeners to incomplete images after HTML renders", async () => {
+      const contentWithImages = "![a](a.png)\n\n![b](b.png)\n\nSome text";
+
+      const { container } = render(MarkdownViewer, {
+        props: {
+          content: contentWithImages,
+          filePath: "/docs/test.md",
+        },
+      });
+
+      // Wait for markdown to render with images
+      await vi.waitFor(() => {
+        const article = container.querySelector("article.markdown-body");
+        expect(article).not.toBeNull();
+        const imgs = article!.querySelectorAll("img");
+        expect(imgs.length).toBe(2);
+      });
+
+      // Images should exist in the rendered output
+      const imgs = container.querySelectorAll("img");
+      expect(imgs.length).toBe(2);
     });
   });
 });

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -13,6 +13,7 @@
     sortMode = "name-asc" as SortMode,
     onsortchange,
     onhelp,
+    helpActive = false,
     filterQuery = "",
     onfilterchange,
     searchMode = false,
@@ -29,6 +30,7 @@
     sortMode?: SortMode;
     onsortchange?: () => void;
     onhelp?: () => void;
+    helpActive?: boolean;
     filterQuery?: string;
     onfilterchange?: (query: string) => void;
     searchMode?: boolean;
@@ -66,7 +68,7 @@
         </button>
       {/if}
       {#if onhelp}
-        <button class="help-btn" onclick={onhelp} title="Help">?</button>
+        <button class="help-btn" class:help-active={helpActive} onclick={onhelp} title="Help">?</button>
       {/if}
       {#if onchangefolder}
         <button class="change-folder-btn" onclick={onchangefolder} title="Change folder">
@@ -196,6 +198,13 @@
     background: rgba(122, 162, 247, 0.1);
     border-color: #7aa2f7;
     color: #7aa2f7;
+  }
+
+  .help-btn.help-active {
+    background: rgba(122, 162, 247, 0.25);
+    border-color: #7aa2f7;
+    color: #7aa2f7;
+    box-shadow: 0 0 6px rgba(122, 162, 247, 0.3);
   }
 
   .change-folder-btn {

--- a/src/lib/components/Sidebar.test.ts
+++ b/src/lib/components/Sidebar.test.ts
@@ -150,6 +150,24 @@ describe("Sidebar", () => {
     expect(onsearchmodechange).toHaveBeenCalledOnce();
   });
 
+  it("highlights help button when helpActive is true", () => {
+    render(Sidebar, {
+      props: { entries: [], selectedPath: "", onselect: vi.fn(), onhelp: vi.fn(), helpActive: true },
+    });
+
+    const helpBtn = screen.getByTitle("Help");
+    expect(helpBtn.classList.contains("help-active")).toBe(true);
+  });
+
+  it("does not highlight help button when helpActive is false", () => {
+    render(Sidebar, {
+      props: { entries: [], selectedPath: "", onselect: vi.fn(), onhelp: vi.fn(), helpActive: false },
+    });
+
+    const helpBtn = screen.getByTitle("Help");
+    expect(helpBtn.classList.contains("help-active")).toBe(false);
+  });
+
   it("shows search results instead of file tree when searchMode is active with a query", () => {
     const searchResults = [
       { path: "/docs/readme.md", name: "readme.md", matches: [{ line_number: 1, line_content: "# README" }] },

--- a/src/lib/services/filesystem.test.ts
+++ b/src/lib/services/filesystem.test.ts
@@ -12,7 +12,7 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
 
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
-import { readDirectoryTree, readFileContents, startWatching, getDocsPath, pickFolder, searchFiles } from "./filesystem";
+import { readDirectoryTree, readFileContents, startWatching, getDocsPath, pickFolder, searchFiles, writeFileContents } from "./filesystem";
 
 const mockOpen = vi.mocked(open);
 
@@ -115,5 +115,18 @@ describe("searchFiles", () => {
 
     expect(mockInvoke).toHaveBeenCalledWith("search_files", { path: "/docs", query: "README" });
     expect(result).toEqual(mockResults);
+  });
+});
+
+describe("writeFileContents", () => {
+  it("calls invoke with correct command, path and content", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+
+    await writeFileContents("/docs/test.md", "# Hello World");
+
+    expect(mockInvoke).toHaveBeenCalledWith("write_file_contents", {
+      path: "/docs/test.md",
+      content: "# Hello World",
+    });
   });
 });

--- a/src/lib/services/filesystem.ts
+++ b/src/lib/services/filesystem.ts
@@ -30,6 +30,10 @@ export async function searchFiles(path: string, query: string): Promise<SearchRe
   return invoke<SearchResult[]>("search_files", { path, query });
 }
 
+export async function writeFileContents(path: string, content: string): Promise<void> {
+  return invoke<void>("write_file_contents", { path, content });
+}
+
 export async function pickFolder(): Promise<string | null> {
   const selected = await open({
     directory: true,

--- a/src/lib/services/highlight.test.ts
+++ b/src/lib/services/highlight.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from "vitest";
-import { extractDiagramLabels, getCodeBlockLineOverlayPosition } from "./highlight";
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  extractDiagramLabels,
+  getCodeBlockLineOverlayPosition,
+  stripMarkdownSyntax,
+  findMatchingBlockElement,
+  findMatchingPreElement,
+  applyBlockHighlight,
+  clearBlockHighlights,
+  getTableCellIndex,
+} from "./highlight";
 
 describe("extractDiagramLabels", () => {
   it("extracts text from square brackets", () => {
@@ -108,5 +117,951 @@ describe("getCodeBlockLineOverlayPosition", () => {
     expect(result!.height).toBe(22);
 
     document.body.removeChild(pre);
+  });
+});
+
+describe("stripMarkdownSyntax", () => {
+  it("strips heading markers", () => {
+    expect(stripMarkdownSyntax("# Heading 1")).toBe("Heading 1");
+    expect(stripMarkdownSyntax("## Heading 2")).toBe("Heading 2");
+    expect(stripMarkdownSyntax("### Heading 3")).toBe("Heading 3");
+    expect(stripMarkdownSyntax("###### Heading 6")).toBe("Heading 6");
+  });
+
+  it("strips bold markers (** and __)", () => {
+    expect(stripMarkdownSyntax("**bold text**")).toBe("bold text");
+    expect(stripMarkdownSyntax("__bold text__")).toBe("bold text");
+    expect(stripMarkdownSyntax("Some **bold** text")).toBe("Some bold text");
+  });
+
+  it("strips italic markers (* and _)", () => {
+    expect(stripMarkdownSyntax("*italic text*")).toBe("italic text");
+    expect(stripMarkdownSyntax("_italic text_")).toBe("italic text");
+    expect(stripMarkdownSyntax("Some *italic* words")).toBe("Some italic words");
+  });
+
+  it("strips inline code backticks", () => {
+    expect(stripMarkdownSyntax("`code`")).toBe("code");
+    expect(stripMarkdownSyntax("Use `npm install` to install")).toBe("Use npm install to install");
+  });
+
+  it("strips link syntax keeping text", () => {
+    expect(stripMarkdownSyntax("[link text](http://example.com)")).toBe("link text");
+    expect(stripMarkdownSyntax("Click [here](url) to continue")).toBe("Click here to continue");
+  });
+
+  it("strips image syntax keeping alt text", () => {
+    expect(stripMarkdownSyntax("![alt text](image.png)")).toBe("alt text");
+  });
+
+  it("strips unordered list markers (-, *, +)", () => {
+    expect(stripMarkdownSyntax("- list item")).toBe("list item");
+    expect(stripMarkdownSyntax("* list item")).toBe("list item");
+    expect(stripMarkdownSyntax("+ list item")).toBe("list item");
+  });
+
+  it("strips ordered list markers", () => {
+    expect(stripMarkdownSyntax("1. first item")).toBe("first item");
+    expect(stripMarkdownSyntax("42. item forty-two")).toBe("item forty-two");
+  });
+
+  it("strips blockquote markers", () => {
+    expect(stripMarkdownSyntax("> quoted text")).toBe("quoted text");
+    expect(stripMarkdownSyntax(">no space")).toBe("no space");
+  });
+
+  it("strips task list markers", () => {
+    expect(stripMarkdownSyntax("- [ ] unchecked task")).toBe("unchecked task");
+    expect(stripMarkdownSyntax("- [x] checked task")).toBe("checked task");
+  });
+
+  it("strips table pipe characters", () => {
+    expect(stripMarkdownSyntax("| cell1 | cell2 | cell3 |")).toBe("cell1 cell2 cell3");
+  });
+
+  it("strips combined formatting", () => {
+    expect(stripMarkdownSyntax("## **Bold** heading with `code`")).toBe("Bold heading with code");
+    expect(stripMarkdownSyntax("- [Link](url) and **bold**")).toBe("Link and bold");
+  });
+
+  it("strips strikethrough markers", () => {
+    expect(stripMarkdownSyntax("~~deleted~~")).toBe("deleted");
+    expect(stripMarkdownSyntax("Some ~~deleted~~ text")).toBe("Some deleted text");
+  });
+
+  it("returns empty string for whitespace-only input", () => {
+    expect(stripMarkdownSyntax("   ")).toBe("");
+    expect(stripMarkdownSyntax("")).toBe("");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(stripMarkdownSyntax("just plain text")).toBe("just plain text");
+  });
+});
+
+describe("findMatchingBlockElement", () => {
+  let container: HTMLDivElement;
+
+  afterEach(() => {
+    container?.remove();
+  });
+
+  function makeContainer(html: string): HTMLDivElement {
+    container = document.createElement("div");
+    container.innerHTML = html;
+    document.body.appendChild(container);
+    return container;
+  }
+
+  it("finds a paragraph element", () => {
+    const el = makeContainer("<p>Hello world</p>");
+    const result = findMatchingBlockElement(el, "Hello world");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("finds a heading element", () => {
+    const el = makeContainer("<h2>Section Title</h2><p>body text</p>");
+    const result = findMatchingBlockElement(el, "Section Title");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("H2");
+  });
+
+  it("finds text inside bold within a paragraph", () => {
+    const el = makeContainer("<p>Some <strong>bold</strong> text</p>");
+    const result = findMatchingBlockElement(el, "Some bold text");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("finds text inside italic within a paragraph", () => {
+    const el = makeContainer("<p>Some <em>italic</em> words</p>");
+    const result = findMatchingBlockElement(el, "Some italic words");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("finds a list item", () => {
+    const el = makeContainer("<ul><li>First item</li><li>Second item</li></ul>");
+    const result = findMatchingBlockElement(el, "Second item");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("LI");
+  });
+
+  it("finds a table cell", () => {
+    const el = makeContainer("<table><tr><td>Cell A</td><td>Cell B</td></tr></table>");
+    const result = findMatchingBlockElement(el, "Cell B");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("TD");
+  });
+
+  it("finds a table header cell", () => {
+    const el = makeContainer("<table><tr><th>Header</th></tr></table>");
+    const result = findMatchingBlockElement(el, "Header");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("TH");
+  });
+
+  it("finds text inside a blockquote paragraph", () => {
+    const el = makeContainer("<blockquote><p>Quoted text here</p></blockquote>");
+    const result = findMatchingBlockElement(el, "Quoted text here");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("finds text with link inside paragraph", () => {
+    const el = makeContainer('<p>Click <a href="#">here</a> to go</p>');
+    const result = findMatchingBlockElement(el, "Click here to go");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("finds text with inline code inside paragraph", () => {
+    const el = makeContainer("<p>Use <code>npm install</code> to install</p>");
+    const result = findMatchingBlockElement(el, "Use npm install to install");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("skips elements inside pre (code blocks)", () => {
+    const el = makeContainer("<pre><code>code line</code></pre><p>code line</p>");
+    const result = findMatchingBlockElement(el, "code line");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("returns null when no match found", () => {
+    const el = makeContainer("<p>Hello world</p>");
+    const result = findMatchingBlockElement(el, "no match here");
+    expect(result).toBeNull();
+  });
+
+  it("returns the most specific match (smallest block)", () => {
+    const el = makeContainer("<ul><li>Nested <strong>bold item</strong></li></ul>");
+    const result = findMatchingBlockElement(el, "Nested bold item");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("LI");
+  });
+});
+
+describe("applyBlockHighlight", () => {
+  let container: HTMLDivElement;
+
+  afterEach(() => {
+    container?.remove();
+  });
+
+  it("adds highlight class to the matching block element", () => {
+    container = document.createElement("div");
+    container.innerHTML = "<p>Target paragraph</p>";
+    document.body.appendChild(container);
+
+    const result = applyBlockHighlight(container, "Target paragraph", "test-highlight");
+    expect(result).toBe(true);
+    expect(container.querySelector("p")!.classList.contains("test-highlight")).toBe(true);
+  });
+
+  it("returns false when no match found", () => {
+    container = document.createElement("div");
+    container.innerHTML = "<p>Some text</p>";
+    document.body.appendChild(container);
+
+    const result = applyBlockHighlight(container, "no match", "test-highlight");
+    expect(result).toBe(false);
+  });
+});
+
+describe("clearBlockHighlights", () => {
+  let container: HTMLDivElement;
+
+  afterEach(() => {
+    container?.remove();
+  });
+
+  it("removes specified highlight class from all elements", () => {
+    container = document.createElement("div");
+    container.innerHTML = "<p class='test-hl'>text1</p><p class='test-hl'>text2</p>";
+    document.body.appendChild(container);
+
+    clearBlockHighlights(container, "test-hl");
+    expect(container.querySelectorAll(".test-hl").length).toBe(0);
+  });
+});
+
+/**
+ * End-to-end active line highlight tests.
+ *
+ * These simulate the full pipeline:
+ *   1. Raw markdown line from the CodeMirror editor (what onactiveline emits)
+ *   2. stripMarkdownSyntax(rawLine) — what MarkdownViewer does
+ *   3. findMatchingBlockElement(container, stripped) — looking in rendered HTML
+ *
+ * The HTML in each test is what `marked` actually produces for that markdown.
+ * If any test fails, the active line highlight is broken for that element type.
+ */
+describe("active line highlight: editor line → strip → find in rendered HTML", () => {
+  let container: HTMLDivElement;
+
+  afterEach(() => {
+    container?.remove();
+  });
+
+  function makeContainer(html: string): HTMLDivElement {
+    container = document.createElement("div");
+    container.innerHTML = html;
+    document.body.appendChild(container);
+    return container;
+  }
+
+  // Simulate the full pipeline
+  function activeLineFindsMatch(rawEditorLine: string, renderedHTML: string): HTMLElement | null {
+    const el = makeContainer(renderedHTML);
+    const stripped = stripMarkdownSyntax(rawEditorLine);
+    if (stripped.length < 2) return null;
+    return findMatchingBlockElement(el, stripped);
+  }
+
+  // --- Headings ---
+
+  it("H1: # Planning Central — Next Steps", () => {
+    const result = activeLineFindsMatch(
+      "# Planning Central — Next Steps",
+      "<h1>Planning Central — Next Steps</h1>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("H1");
+  });
+
+  it("H2: ## Project Context", () => {
+    const result = activeLineFindsMatch(
+      "## Project Context",
+      "<h2>Project Context</h2><p>some body</p>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("H2");
+  });
+
+  it("H3: ### Status: DONE", () => {
+    const result = activeLineFindsMatch(
+      "### Status: DONE",
+      "<h3>Status: DONE</h3>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("H3");
+  });
+
+  it("H3 with inline code: ### Solution: Rust `include_str!`", () => {
+    const result = activeLineFindsMatch(
+      "### Solution: Rust `include_str!`",
+      "<h3>Solution: Rust <code>include_str!</code></h3>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("H3");
+  });
+
+  it("H3 with bold: ### Current Test Count: **120 frontend**", () => {
+    const result = activeLineFindsMatch(
+      "### Current Test Count: **120 frontend**",
+      "<h3>Current Test Count: <strong>120 frontend</strong></h3>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("H3");
+  });
+
+  // --- Plain paragraphs ---
+
+  it("simple paragraph", () => {
+    const result = activeLineFindsMatch(
+      "Desktop markdown viewer built with Tauri.",
+      "<p>Desktop markdown viewer built with Tauri.</p>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  // --- Paragraphs with inline formatting ---
+
+  it("paragraph with bold: **bold text** in the middle", () => {
+    const result = activeLineFindsMatch(
+      "Desktop markdown viewer built with **Tauri 2.10 + Svelte 5 + TypeScript**.",
+      "<p>Desktop markdown viewer built with <strong>Tauri 2.10 + Svelte 5 + TypeScript</strong>.</p>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("paragraph with italic", () => {
+    const result = activeLineFindsMatch(
+      "This is *very important* information.",
+      "<p>This is <em>very important</em> information.</p>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("paragraph with inline code: `backtick` words", () => {
+    const result = activeLineFindsMatch(
+      "The `notify` crate for native file watching.",
+      "<p>The <code>notify</code> crate for native file watching.</p>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("paragraph with multiple inline code spans", () => {
+    const result = activeLineFindsMatch(
+      "Uses `$state()`, `$derived()`, `$effect()`, `$props()` from Svelte 5.",
+      '<p>Uses <code>$state()</code>, <code>$derived()</code>, <code>$effect()</code>, <code>$props()</code> from Svelte 5.</p>'
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("paragraph with link", () => {
+    const result = activeLineFindsMatch(
+      "See the [Mermaid documentation](https://mermaid.js.org/) for details.",
+      '<p>See the <a href="https://mermaid.js.org/">Mermaid documentation</a> for details.</p>'
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("paragraph with bold + inline code + link mixed", () => {
+    const result = activeLineFindsMatch(
+      "**Trade-off:** The help content is frozen at build time. Any edits to the `.md` file require a rebuild.",
+      '<p><strong>Trade-off:</strong> The help content is frozen at build time. Any edits to the <code>.md</code> file require a rebuild.</p>'
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("paragraph with bold italic: ***bold italic***", () => {
+    const result = activeLineFindsMatch(
+      "This is ***bold italic*** text here.",
+      "<p>This is <em><strong>bold italic</strong></em> text here.</p>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  // --- Unordered list items ---
+
+  it("simple list item: - item text", () => {
+    const result = activeLineFindsMatch(
+      "- File tree with expand/collapse",
+      "<ul>\n<li>File tree with expand/collapse</li>\n</ul>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("LI");
+  });
+
+  it("list item with inline code: - `lib.rs` — Command registration", () => {
+    const result = activeLineFindsMatch(
+      "- `lib.rs` — Command registration (modify)",
+      "<ul>\n<li><code>lib.rs</code> — Command registration (modify)</li>\n</ul>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("LI");
+  });
+
+  it("list item with bold: - **Rust backend:** description", () => {
+    const result = activeLineFindsMatch(
+      "- **Rust backend:** `src-tauri/src/` — file watching, event emission",
+      '<ul>\n<li><strong>Rust backend:</strong> <code>src-tauri/src/</code> — file watching, event emission</li>\n</ul>'
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("LI");
+  });
+
+  it("list item with link: - [link](url) text", () => {
+    const result = activeLineFindsMatch(
+      "- [Mermaid documentation](https://mermaid.js.org/) for diagrams",
+      '<ul>\n<li><a href="https://mermaid.js.org/">Mermaid documentation</a> for diagrams</li>\n</ul>'
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("LI");
+  });
+
+  // --- Ordered list items ---
+
+  it("ordered list: 1. Open the app", () => {
+    const result = activeLineFindsMatch(
+      "1. Open the app",
+      "<ol>\n<li>Open the app</li>\n<li>Browse files</li>\n</ol>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("LI");
+  });
+
+  it("ordered list with formatting: 1. **`switchToFolder()`** — after loadTree", () => {
+    const result = activeLineFindsMatch(
+      '1. **`switchToFolder()`** — after `loadTree()`, auto-select the first file',
+      '<ol>\n<li><strong><code>switchToFolder()</code></strong> — after <code>loadTree()</code>, auto-select the first file</li>\n</ol>'
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("LI");
+  });
+
+  // --- Blockquotes ---
+
+  it("blockquote: > quoted text", () => {
+    const result = activeLineFindsMatch(
+      "> Planning is bringing the future into the present.",
+      "<blockquote>\n<p>Planning is bringing the future into the present.</p>\n</blockquote>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  // --- Table rows ---
+
+  it("table header row: | Feature | Status | Notes |", () => {
+    const result = activeLineFindsMatch(
+      "| Feature | Status | Notes |",
+      '<div class="table-wrapper"><table>\n<thead>\n<tr>\n<th>Feature</th>\n<th>Status</th>\n<th>Notes</th>\n</tr>\n</thead>\n</table></div>'
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("TH");
+  });
+
+  it("table data row: | File tree sidebar | Done | Recursive |", () => {
+    const result = activeLineFindsMatch(
+      "| File tree sidebar | Done | Recursive, filterable |",
+      '<div class="table-wrapper"><table>\n<tbody>\n<tr>\n<td>File tree sidebar</td>\n<td>Done</td>\n<td>Recursive, filterable</td>\n</tr>\n</tbody>\n</table></div>'
+    );
+    expect(result).not.toBeNull();
+    // Should match the most specific cell
+    expect(["TD", "TH"]).toContain(result!.tagName);
+  });
+
+  it("table separator row: |---|---| returns null (no visible content)", () => {
+    // Table separator lines like |---|---| are not rendered as visible elements
+    const stripped = stripMarkdownSyntax("|---------|--------|-------|");
+    // After stripping pipes and collapsing: "--------- -------- -------"
+    // After trim: "--------- -------- -------"
+    // This shouldn't match any meaningful content
+    const el = makeContainer('<div class="table-wrapper"><table><thead><tr><th>A</th></tr></thead></table></div>');
+    const result = findMatchingBlockElement(el, stripped);
+    // It's OK if this is null — separator lines have no rendered content
+    // The important thing is it doesn't crash or match the wrong element
+    expect(true).toBe(true); // Just verifying it doesn't throw
+  });
+
+  // --- Horizontal rules ---
+
+  it("horizontal rule: --- (returns null, no block to highlight)", () => {
+    const stripped = stripMarkdownSyntax("---");
+    // "---" is only 3 chars but they're all dashes, which become "---" after strip
+    // This is fine — hr has no text content to match
+    expect(stripped).toBe("---");
+  });
+
+  // --- Lines that should NOT match (code fence markers, blank lines, etc.) ---
+
+  it("code fence opening: ``` returns null (too short after strip)", () => {
+    const stripped = stripMarkdownSyntax("```typescript");
+    // Backticks get stripped, leaving "typescript" — but this is a fence marker
+    // We don't want it to match a random paragraph that says "typescript"
+    // The stripped result is just the language name
+    expect(stripped.length).toBeGreaterThan(0); // "typescript" remains
+  });
+
+  it("code fence closing: ``` remains unchanged (no content between backticks)", () => {
+    const stripped = stripMarkdownSyntax("```");
+    // `[^`]+` requires at least one non-backtick char, so ``` doesn't match
+    expect(stripped).toBe("```");
+  });
+
+  it("empty line returns empty", () => {
+    const stripped = stripMarkdownSyntax("");
+    expect(stripped).toBe("");
+  });
+
+  // --- Real examples from docs/nextsteps.md (the file in the screenshot) ---
+
+  it("real: The help button loads `How to Use Planning Central.md` from the app's `docs/` folder...", () => {
+    const rawLine = "The help button loads `How to Use Planning Central.md` from the app's `docs/` folder at runtime using `get_docs_path()`. This only works if the docs folder exists relative to the executable. When the app is installed to Program Files or run from a different location, the help file may not be found.";
+    const rendered = "<p>The help button loads <code>How to Use Planning Central.md</code> from the app's <code>docs/</code> folder at runtime using <code>get_docs_path()</code>. This only works if the docs folder exists relative to the executable. When the app is installed to Program Files or run from a different location, the help file may not be found.</p>";
+    const result = activeLineFindsMatch(rawLine, rendered);
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("real: Compile the help file directly into the binary at build time using Rust's `include_str!` macro.", () => {
+    const rawLine = "Compile the help file directly into the binary at build time using Rust's `include_str!` macro. This reads the file at compile time and embeds it as a string constant in the executable. No runtime file access needed.";
+    const rendered = "<p>Compile the help file directly into the binary at build time using Rust's <code>include_str!</code> macro. This reads the file at compile time and embeds it as a string constant in the executable. No runtime file access needed.</p>";
+    const result = activeLineFindsMatch(rawLine, rendered);
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("real: ## PRIORITY 0: Embed Help File in Binary", () => {
+    const result = activeLineFindsMatch(
+      "## PRIORITY 0: Embed Help File in Binary",
+      "<h2>PRIORITY 0: Embed Help File in Binary</h2>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("H2");
+  });
+
+  it("real: **Trade-off:** The help content is frozen at build time...", () => {
+    const rawLine = "**Trade-off:** The help content is frozen at build time. Any edits to the `.md` file require a rebuild. This is fine since the file only changes when we ship new features (which requires a rebuild anyway).";
+    const rendered = '<p><strong>Trade-off:</strong> The help content is frozen at build time. Any edits to the <code>.md</code> file require a rebuild. This is fine since the file only changes when we ship new features (which requires a rebuild anyway).</p>';
+    const result = activeLineFindsMatch(rawLine, rendered);
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("real: The frontend calls `invoke(\"get_help_content\")` instead of reading a file path.", () => {
+    const rawLine = 'The frontend calls `invoke("get_help_content")` instead of reading a file path. Works from anywhere — installed, portable, any folder.';
+    const rendered = '<p>The frontend calls <code>invoke(&quot;get_help_content&quot;)</code> instead of reading a file path. Works from anywhere — installed, portable, any folder.</p>';
+    const result = activeLineFindsMatch(rawLine, rendered);
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("real: 1. **`switchToFolder()`** — after `loadTree()`...", () => {
+    const rawLine = '1. **`switchToFolder()`** — after `loadTree()`, if no last-selected file was restored, auto-select the first file';
+    const rendered = '<ol>\n<li><strong><code>switchToFolder()</code></strong> — after <code>loadTree()</code>, if no last-selected file was restored, auto-select the first file</li>\n</ol>';
+    const result = activeLineFindsMatch(rawLine, rendered);
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("LI");
+  });
+
+  it("real: ### Fix Location", () => {
+    const result = activeLineFindsMatch(
+      "### Fix Location",
+      "<h3>Fix Location</h3>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("H3");
+  });
+
+  it("real: `src/App.svelte` — two places need the same logic:", () => {
+    const rawLine = "`src/App.svelte` — two places need the same logic:";
+    const rendered = "<p><code>src/App.svelte</code> — two places need the same logic:</p>";
+    const result = activeLineFindsMatch(rawLine, rendered);
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  // --- Code block content lines (cursor inside a fenced code block) ---
+
+  it("code block line: const HELP_CONTENT = include_str!(...)", () => {
+    const rawLine = 'const HELP_CONTENT: &str = include_str!("../../docs/How to Use Planning Central.md");';
+    // This line is INSIDE a <pre><code>, so findMatchingBlockElement skips it
+    const rendered = '<pre class="line-numbers"><code class="hljs">const HELP_CONTENT: &amp;str = include_str!(&quot;../../docs/How to Use Planning Central.md&quot;);</code></pre>';
+    const el = makeContainer(rendered);
+    const stripped = stripMarkdownSyntax(rawLine);
+    const result = findMatchingBlockElement(el, stripped);
+    // Currently returns null because we skip <pre> content
+    // This is a known limitation — code block lines need a different highlight strategy
+    expect(result).toBeNull();
+  });
+
+  // --- Edge cases ---
+
+  it("bold at start of line: **Status: DONE**", () => {
+    const result = activeLineFindsMatch(
+      "**Status: DONE**",
+      "<p><strong>Status: DONE</strong></p>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("line with only bold: **Newest**", () => {
+    const result = activeLineFindsMatch(
+      "**Newest**",
+      "<p><strong>Newest</strong></p>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+  });
+
+  it("nested list item with code: - `models.rs` — FileEntry struct", () => {
+    const result = activeLineFindsMatch(
+      "  - Contains: file watching, event emission",
+      "<ul>\n<li>Rust backend\n<ul>\n<li>Contains: file watching, event emission</li>\n</ul>\n</li>\n</ul>"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("LI");
+  });
+
+  it("image line: ![Planning Central Logo](../img/logo.png)", () => {
+    const rawLine = '![Planning Central Logo](../img/logo.png "The Planning Central polar bear")';
+    const stripped = stripMarkdownSyntax(rawLine);
+    // Image regex strips ![alt](url "title") → alt text only (title is inside parens)
+    expect(stripped).toBe("Planning Central Logo");
+  });
+});
+
+describe("findMatchingPreElement", () => {
+  let container: HTMLDivElement;
+
+  afterEach(() => {
+    container?.remove();
+  });
+
+  function makeContainer(html: string): HTMLDivElement {
+    container = document.createElement("div");
+    container.innerHTML = html;
+    document.body.appendChild(container);
+    return container;
+  }
+
+  it("finds a code block pre containing the line text", () => {
+    const el = makeContainer(
+      '<pre class="line-numbers"><code class="hljs">function hello() {\n  console.log("Hello");\n}</code></pre>'
+    );
+    const result = findMatchingPreElement(el, '  console.log("Hello");');
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("PRE");
+  });
+
+  it("finds a plain code block with matching line", () => {
+    const el = makeContainer(
+      '<pre><code>line one\nline two\nline three</code></pre>'
+    );
+    const result = findMatchingPreElement(el, "line two");
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("PRE");
+  });
+
+  it("finds the correct pre when multiple code blocks exist", () => {
+    const el = makeContainer(
+      '<pre><code>block one content</code></pre><pre><code>block two content</code></pre>'
+    );
+    const result = findMatchingPreElement(el, "block two content");
+    expect(result).not.toBeNull();
+    expect(result!.textContent).toContain("block two");
+  });
+
+  it("finds mermaid pre block from mermaid source line", () => {
+    const el = makeContainer(
+      '<pre class="mermaid">flowchart TD\n    A[Start] --> B[End]</pre>'
+    );
+    const result = findMatchingPreElement(el, "    A[Start] --> B[End]");
+    expect(result).not.toBeNull();
+    expect(result!.classList.contains("mermaid")).toBe(true);
+  });
+
+  it("finds bob-rendered pre block from ASCII art line", () => {
+    const el = makeContainer(
+      '<pre class="bob-rendered"><svg>some svg</svg></pre><p>text</p>'
+    );
+    // After rendering, the original ASCII text is gone (replaced by SVG).
+    // We can't match text directly. findMatchingPreElement should return null here.
+    const result = findMatchingPreElement(el, "┌──────────┐");
+    // SVG doesn't contain the original text, so no match expected
+    expect(result).toBeNull();
+  });
+
+  it("returns null when line text doesn't match any pre", () => {
+    const el = makeContainer(
+      '<pre><code>some code</code></pre><p>paragraph</p>'
+    );
+    const result = findMatchingPreElement(el, "no match here");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty container", () => {
+    const el = makeContainer("<p>just a paragraph</p>");
+    const result = findMatchingPreElement(el, "anything");
+    expect(result).toBeNull();
+  });
+
+  it("matches JSON code block content", () => {
+    const el = makeContainer(
+      '<pre class="line-numbers"><code class="hljs">{\n  "app": "Planning Central",\n  "version": "0.1.0"\n}</code></pre>'
+    );
+    const result = findMatchingPreElement(el, '  "app": "Planning Central",');
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("PRE");
+  });
+
+  it("matches Rust code block content", () => {
+    const el = makeContainer(
+      '<pre class="line-numbers"><code class="hljs">const HELP_CONTENT: &amp;str = include_str!("../../docs/help.md");</code></pre>'
+    );
+    // textContent decodes HTML entities, so &amp; becomes &
+    const result = findMatchingPreElement(el, 'const HELP_CONTENT: &str = include_str!');
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("PRE");
+  });
+
+  it("matches mermaid diagram keyword lines", () => {
+    const el = makeContainer(
+      '<pre class="mermaid">sequenceDiagram\n    User->>Claude: Describe what you need</pre>'
+    );
+    const result = findMatchingPreElement(el, "    User->>Claude: Describe what you need");
+    expect(result).not.toBeNull();
+  });
+
+  it("matches mermaid rendered SVG container when original text preserved", () => {
+    // After mermaid.run(), the pre contains an SVG but the class stays "mermaid"
+    // The original text might still be in a data attribute or aria-label
+    // But typically mermaid replaces the textContent. Test the before-render case.
+    const el = makeContainer(
+      '<pre class="mermaid">flowchart TD\n    A --> B</pre>'
+    );
+    const result = findMatchingPreElement(el, "flowchart TD");
+    expect(result).not.toBeNull();
+  });
+});
+
+describe("findMatchingBlockElement with positionRatio (disambiguation)", () => {
+  let container: HTMLDivElement;
+
+  afterEach(() => {
+    container?.remove();
+  });
+
+  function makeContainer(html: string): HTMLDivElement {
+    container = document.createElement("div");
+    container.innerHTML = html;
+    document.body.appendChild(container);
+    return container;
+  }
+
+  it("returns first match when no positionRatio is provided (backward compatible)", () => {
+    const el = makeContainer(
+      "<h3>Tests to Write</h3><p>some text</p><h3>Tests to Write</h3>"
+    );
+    const result = findMatchingBlockElement(el, "Tests to Write");
+    expect(result).not.toBeNull();
+    // Without position info, returns first match
+    expect(result).toBe(el.querySelectorAll("h3")[0]);
+  });
+
+  it("selects second match when positionRatio indicates bottom of document", () => {
+    const el = makeContainer(
+      "<h3>Tests to Write</h3><p>filler</p><p>filler</p><p>filler</p><h3>Tests to Write</h3>"
+    );
+    // 5 block elements total, second h3 is at index 4 (last).
+    // positionRatio = 1.0 (bottom of document) should pick the second h3.
+    const result = findMatchingBlockElement(el, "Tests to Write", 1.0);
+    expect(result).not.toBeNull();
+    expect(result).toBe(el.querySelectorAll("h3")[1]);
+  });
+
+  it("selects first match when positionRatio indicates top of document", () => {
+    const el = makeContainer(
+      "<h3>Tests to Write</h3><p>filler</p><p>filler</p><p>filler</p><h3>Tests to Write</h3>"
+    );
+    // positionRatio = 0.0 (top) should pick the first h3
+    const result = findMatchingBlockElement(el, "Tests to Write", 0.0);
+    expect(result).not.toBeNull();
+    expect(result).toBe(el.querySelectorAll("h3")[0]);
+  });
+
+  it("selects middle match when positionRatio indicates middle of document", () => {
+    const el = makeContainer(
+      "<h3>Status</h3><p>filler1</p><h3>Status</h3><p>filler2</p><h3>Status</h3>"
+    );
+    // 5 elements: h3(0), p(1), h3(2), p(3), h3(4)
+    // Middle h3 at index 2. ratio = 2/4 = 0.5
+    // positionRatio = 0.5 should pick the middle h3
+    const result = findMatchingBlockElement(el, "Status", 0.5);
+    expect(result).not.toBeNull();
+    expect(result).toBe(el.querySelectorAll("h3")[1]);
+  });
+
+  it("works with single match regardless of positionRatio", () => {
+    const el = makeContainer(
+      "<p>unique paragraph</p><p>other text</p>"
+    );
+    const result = findMatchingBlockElement(el, "unique paragraph", 0.8);
+    expect(result).not.toBeNull();
+    expect(result!.tagName).toBe("P");
+    expect(result!.textContent).toBe("unique paragraph");
+  });
+
+  it("picks closest match when positionRatio is between two matches", () => {
+    const el = makeContainer(
+      "<h2>Section</h2><p>a</p><p>b</p><p>c</p><p>d</p><p>e</p><p>f</p><p>g</p><p>h</p><h2>Section</h2>"
+    );
+    // 10 elements. First h2 at index 0 (ratio 0.0), second at index 9 (ratio 1.0)
+    // positionRatio 0.7 is closer to 1.0, should pick second h2
+    const result = findMatchingBlockElement(el, "Section", 0.7);
+    expect(result).not.toBeNull();
+    expect(result).toBe(el.querySelectorAll("h2")[1]);
+  });
+
+  it("real scenario: duplicate heading '6. Tests to Write' at different positions", () => {
+    // Simulating the actual bug: line 196 of a 250-line document has this heading,
+    // but an earlier heading at line 50 has similar text
+    const el = makeContainer(
+      '<h4>5. Tests to Write (TDD)</h4>' +
+      '<p>filler</p><p>filler</p><p>filler</p><p>filler</p>' +
+      '<p>filler</p><p>filler</p><p>filler</p><p>filler</p>' +
+      '<h4>6. Tests to Write (TDD — write these FIRST)</h4>'
+    );
+    // 10 elements. The first h4 contains "Tests to Write" at index 0.
+    // The second h4 contains "Tests to Write" at index 9.
+    // Line 196 of 250 lines → ratio ≈ 0.78
+    const positionRatio = (196 - 1) / (250 - 1);
+    const result = findMatchingBlockElement(el, "Tests to Write", positionRatio);
+    expect(result).not.toBeNull();
+    // Should pick the SECOND h4 (closer to position 0.78)
+    expect(result).toBe(el.querySelectorAll("h4")[1]);
+  });
+
+  it("falls back to table row matching when no exact block match (with positionRatio)", () => {
+    const el = makeContainer(
+      '<table><tr><th>Feature</th><th>Status</th></tr></table>'
+    );
+    // "Feature Status" doesn't match any single element, but table row fallback should work
+    const result = findMatchingBlockElement(el, "Feature Status", 0.5);
+    expect(result).not.toBeNull();
+  });
+});
+
+describe("getTableCellIndex", () => {
+  it("returns 0 for cursor in the first cell", () => {
+    // | Layer | Choice | Why |
+    // Col 3 is inside "Layer"
+    expect(getTableCellIndex("| Layer | Choice | Why |", 3)).toBe(0);
+  });
+
+  it("returns 1 for cursor in the second cell", () => {
+    // | Layer | Choice | Why |
+    // Col 11 is inside "Choice"
+    expect(getTableCellIndex("| Layer | Choice | Why |", 11)).toBe(1);
+  });
+
+  it("returns 2 for cursor in the third cell", () => {
+    // | Layer | Choice | Why |
+    // Col 20 is inside "Why"
+    expect(getTableCellIndex("| Layer | Choice | Why |", 20)).toBe(2);
+  });
+
+  it("returns 0 for cursor on the leading pipe", () => {
+    expect(getTableCellIndex("| Layer | Choice | Why |", 1)).toBe(0);
+  });
+
+  it("returns correct index for cursor on a pipe between cells", () => {
+    // | Layer | Choice | Why |
+    // Col 9 is the pipe between Layer and Choice — should map to the next cell
+    expect(getTableCellIndex("| Layer | Choice | Why |", 9)).toBe(1);
+  });
+
+  it("returns -1 for non-table lines", () => {
+    expect(getTableCellIndex("Just a normal line", 5)).toBe(-1);
+  });
+
+  it("returns -1 for separator lines", () => {
+    expect(getTableCellIndex("|-------|---------|-----|", 5)).toBe(-1);
+  });
+
+  it("handles cells with special content like bold", () => {
+    // | Name | **Tauri 2.x** | fast |
+    expect(getTableCellIndex("| Name | **Tauri 2.x** | fast |", 15)).toBe(1);
+  });
+});
+
+describe("findMatchingBlockElement with cellIndex (table cell targeting)", () => {
+  function makeContainer(html: string): HTMLElement {
+    const el = document.createElement("div");
+    el.innerHTML = html;
+    return el;
+  }
+
+  it("highlights the correct cell when cellIndex is provided", () => {
+    const el = makeContainer(
+      '<table><tr><th>Layer</th><th>Choice</th><th>Why</th></tr>' +
+      '<tr><td>Desktop</td><td>Tauri 2.x</td><td>Fast</td></tr></table>'
+    );
+    // cellIndex=2 should highlight "Why" header
+    const result = findMatchingBlockElement(el, "Layer Choice Why", 0, 2);
+    expect(result).not.toBeNull();
+    expect(result!.textContent).toBe("Why");
+  });
+
+  it("highlights first cell when cellIndex is 0", () => {
+    const el = makeContainer(
+      '<table><tr><th>Layer</th><th>Choice</th><th>Why</th></tr></table>'
+    );
+    const result = findMatchingBlockElement(el, "Layer Choice Why", 0, 0);
+    expect(result).not.toBeNull();
+    expect(result!.textContent).toBe("Layer");
+  });
+
+  it("falls back to first cell when cellIndex exceeds available cells", () => {
+    const el = makeContainer(
+      '<table><tr><th>Alpha</th><th>Beta</th></tr></table>'
+    );
+    const result = findMatchingBlockElement(el, "Alpha Beta", 0, 5);
+    expect(result).not.toBeNull();
+    // Should fall back to first cell since index 5 doesn't exist
+    expect(result!.textContent).toBe("Alpha");
+  });
+
+  it("ignores cellIndex for non-table matches", () => {
+    const el = makeContainer('<p>Hello world</p>');
+    // cellIndex is irrelevant for paragraph matches
+    const result = findMatchingBlockElement(el, "Hello world", 0, 1);
+    expect(result).not.toBeNull();
+    expect(result!.textContent).toBe("Hello world");
   });
 });

--- a/src/lib/services/highlight.ts
+++ b/src/lib/services/highlight.ts
@@ -55,3 +55,190 @@ export function extractDiagramLabels(text: string): string[] {
   }
   return labels;
 }
+
+/**
+ * Strip markdown syntax from a raw markdown line, leaving only the visible text content.
+ * Used to match editor lines against rendered DOM text.
+ *
+ * IMPORTANT: Inline code must be stripped FIRST (before italic/bold) because
+ * content inside backticks (e.g. `get_docs_path()`) contains underscores that
+ * would be incorrectly matched by the italic regex `_(.+?)_`.
+ */
+export function stripMarkdownSyntax(text: string): string {
+  return text
+    // Leading whitespace (indented list items)
+    .replace(/^\s+/, '')
+    // Headings
+    .replace(/^#{1,6}\s+/, '')
+    // Task list markers (must come before list markers)
+    .replace(/^[-*+]\s+\[[ x]\]\s+/i, '')
+    // Unordered list markers
+    .replace(/^[-*+]\s+/, '')
+    // Ordered list markers
+    .replace(/^\d+\.\s+/, '')
+    // Blockquote markers
+    .replace(/^>\s*/, '')
+    // Inline code — MUST come before bold/italic to protect underscores inside code spans
+    .replace(/`([^`]+)`/g, '$1')
+    // Images with optional title: ![alt](url "title")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    // Links
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    // Bold (** and __)
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/__(.+?)__/g, '$1')
+    // Strikethrough
+    .replace(/~~(.+?)~~/g, '$1')
+    // Italic (* and _) — use word-boundary-aware regex to avoid matching underscores in identifiers
+    .replace(/(?<!\w)\*(.+?)\*(?!\w)/g, '$1')
+    .replace(/(?<!\w)_(.+?)_(?!\w)/g, '$1')
+    // Table pipe characters
+    .replace(/\|/g, ' ')
+    // Collapse multiple spaces
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+/**
+ * Determine which table cell (0-indexed) the cursor column falls into.
+ * Returns -1 if the line is not a table row or is a separator line.
+ */
+export function getTableCellIndex(lineText: string, column: number): number {
+  // Must start with | to be a table row
+  if (!lineText.trimStart().startsWith('|')) return -1;
+  // Separator lines like |---|---|---| are not data rows
+  if (/^\s*\|[\s\-:|]+\|\s*$/.test(lineText)) return -1;
+
+  let cellIndex = -1;
+  for (let i = 0; i < column && i < lineText.length; i++) {
+    if (lineText[i] === '|') {
+      cellIndex++;
+    }
+  }
+  return Math.max(0, cellIndex);
+}
+
+/**
+ * Find the best matching block-level element whose textContent contains the target text.
+ * Searches p, h1-h6, li, td, th, dd, dt elements, skipping those inside <pre>.
+ *
+ * When positionRatio (0..1) is provided and multiple elements match, picks the one
+ * closest to the expected document position. This prevents matching the wrong element
+ * when similar text appears at multiple locations (e.g. repeated heading text).
+ *
+ * For table rows (where stripped text = "cell1 cell2 cell3"), we also try matching
+ * individual words/phrases against td/th cells. When cellIndex is provided, returns
+ * the specific cell at that index instead of the first cell.
+ */
+export function findMatchingBlockElement(
+  container: HTMLElement,
+  text: string,
+  positionRatio?: number,
+  cellIndex?: number,
+): HTMLElement | null {
+  const blockSelectors = 'p, h1, h2, h3, h4, h5, h6, li, td, th, dd, dt';
+  const allBlocks = Array.from(container.querySelectorAll(blockSelectors));
+  const nonPreBlocks = allBlocks.filter(b => !b.closest('pre'));
+
+  // First pass: exact substring match in textContent
+  const matches: { element: HTMLElement; index: number }[] = [];
+  for (let i = 0; i < nonPreBlocks.length; i++) {
+    const tc = (nonPreBlocks[i].textContent ?? '').trim();
+    if (tc.includes(text)) {
+      matches.push({ element: nonPreBlocks[i] as HTMLElement, index: i });
+    }
+  }
+
+  if (matches.length > 0) {
+    // Single match or no position info → return first match (backward compatible)
+    if (matches.length === 1 || positionRatio === undefined) {
+      return matches[0].element;
+    }
+    // Multiple matches + position info → pick the one closest to expected position
+    return pickClosestByPosition(nonPreBlocks.length, matches, positionRatio);
+  }
+
+  // Second pass: for table row lines, try matching individual cell content.
+  // A stripped table row like "Feature Status Notes" won't match any single <th>/<td>,
+  // but the individual words match separate cells. Find a <tr> where most cells match.
+  const cells = text.split(/\s{2,}|\s+/).filter(w => w.length > 1);
+  if (cells.length >= 2) {
+    const rows = container.querySelectorAll('tr');
+    for (const row of rows) {
+      const cellEls = row.querySelectorAll('td, th');
+      if (cellEls.length === 0) continue;
+      let matchCount = 0;
+      for (const cell of cellEls) {
+        const cellText = (cell.textContent ?? '').trim();
+        if (cells.some(c => cellText.includes(c))) matchCount++;
+      }
+      // If most cells match, highlight the targeted cell (or first if no index)
+      if (matchCount >= Math.ceil(cellEls.length * 0.5)) {
+        if (cellIndex !== undefined && cellIndex >= 0 && cellIndex < cellEls.length) {
+          return cellEls[cellIndex] as HTMLElement;
+        }
+        return cellEls[0] as HTMLElement;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Pick the matching element whose document-order position is closest to the expected ratio.
+ */
+function pickClosestByPosition(
+  totalBlocks: number,
+  matches: { element: HTMLElement; index: number }[],
+  positionRatio: number,
+): HTMLElement {
+  let bestMatch = matches[0].element;
+  let bestDistance = Infinity;
+
+  for (const m of matches) {
+    const matchRatio = totalBlocks > 1 ? m.index / (totalBlocks - 1) : 0;
+    const distance = Math.abs(matchRatio - positionRatio);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestMatch = m.element;
+    }
+  }
+
+  return bestMatch;
+}
+
+/**
+ * Find a <pre> element whose textContent contains the given line text.
+ * Used for active line highlighting when the cursor is inside a code block or diagram.
+ */
+export function findMatchingPreElement(container: HTMLElement, text: string): HTMLElement | null {
+  const pres = container.querySelectorAll('pre');
+  for (const pre of pres) {
+    const tc = pre.textContent ?? '';
+    if (tc.includes(text)) {
+      return pre as HTMLElement;
+    }
+  }
+  return null;
+}
+
+/**
+ * Apply a highlight class to the block-level element that matches the given text.
+ * Returns true if a match was found and highlighted.
+ */
+export function applyBlockHighlight(container: HTMLElement, text: string, className: string): boolean {
+  const block = findMatchingBlockElement(container, text);
+  if (!block) return false;
+  block.classList.add(className);
+  return true;
+}
+
+/**
+ * Remove a highlight class from all elements in the container.
+ */
+export function clearBlockHighlights(container: HTMLElement, className: string): void {
+  container.querySelectorAll(`.${className}`).forEach((el) => {
+    el.classList.remove(className);
+  });
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,8 @@ export interface OpenPane {
   id: string;
   path: string;
   content: string;
+  editMode?: boolean;
+  readOnly?: boolean;
 }
 
 export interface SearchMatch {


### PR DESCRIPTION
## Summary

- **Split-pane markdown editor** — CodeMirror 6 on the left, live MarkdownViewer preview on the right. Per-pane Edit/View toggle via Ctrl+E or toolbar icons.
- **Auto-save** with 1s debounce and Ctrl+S for immediate save. New `write_file_contents` Rust command.
- **Bidirectional scroll sync** — scrolling either pane proportionally scrolls the other.
- **Active line highlighting** — cursor position in editor highlights the corresponding rendered element in the preview (headings, paragraphs, code blocks, table cells).
- **Table cell targeting** — when the cursor is on a table row, the specific cell under the cursor is highlighted (not just the first cell).
- **Image layout shift fix** — search results that scroll to content below images now re-scroll after images finish loading, preventing first-click misalignment.
- **Search highlight in editor** — CodeMirror decorations match the preview's amber search highlighting.
- **Watcher feedback loop prevention** — own writes are tracked to prevent the file watcher from reloading content being edited.
- Version bumped to **v0.4.0**.

## Test plan

- [x] `npx vitest run` — 264 frontend tests pass (13 test files)
- [x] `cargo test` — 23 Rust tests pass
- [x] `npx svelte-check` — 0 errors, 1 pre-existing warning
- [x] `npx tauri build` — MSI and NSIS installers produced
- [ ] Manual: Open a file in edit mode, verify editor and preview scroll together
- [ ] Manual: Move cursor in editor, verify correct element highlights in preview
- [ ] Manual: Place cursor on different table cells, verify the right cell highlights
- [ ] Manual: Search for text below images, verify first click scrolls correctly
- [ ] Manual: Ctrl+E toggles edit/view, Ctrl+S saves, auto-save fires after 1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)