### PR TITLE
feat: jump list, loading skeleton, logo empty state

### DIFF
--- a/docs/How to Use Polar Markdown.md
+++ b/docs/How to Use Polar Markdown.md
@@ -139,6 +139,17 @@ Click the **?** button to open this guide at any time, no matter what folder you
 
 ---
 
+## Jump List (Windows Taskbar)
+
+When you right-click the Polar Markdown icon in the Windows taskbar, a **Recent Folders** category shows the folders you've recently opened. Click any folder to instantly switch to it.
+
+- Folders are added to the jump list whenever you open or switch to a new folder
+- The list holds up to 10 recent folders (most recent first)
+- Stale entries (folders that no longer exist) are automatically cleaned up on app launch
+- If the app is already running, clicking a jump list folder switches the existing window to that folder
+
+---
+
 ## Reading Layout
 
 The markdown viewer has two reading layout modes, toggled with buttons in the top-right corner of the content area:

--- a/docs/test.md
+++ b/docs/test.md
@@ -279,4 +279,15 @@ Clicking a `#hash` link smooth-scrolls to the matching heading. Try these — ea
 
 ---
 
+## Jump List (Windows Taskbar)
+
+Right-click the Polar Markdown icon in the Windows taskbar to see **Recent Folders**. To test:
+
+1. Open 3 different folders using the folder picker
+2. Right-click the taskbar icon — all 3 should appear under "Recent Folders"
+3. Delete one of the folders on disk, then relaunch the app — the stale folder should disappear
+4. Click a folder in the jump list — the app should switch to that folder
+
+---
+
 *This file is a rendering museum — every feature of Polar Markdown displayed in one place.*

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tempfile",
  "walkdir",
+ "windows",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,5 +30,13 @@ svgbob = "0.7"
 tauri-plugin-single-instance = "2"
 tauri-plugin-shell = "2"
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.61", features = [
+    "Win32_UI_Shell",
+    "Win32_UI_Shell_Common",
+    "Win32_System_Com",
+    "Win32_Foundation",
+] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands/filesystem.rs
+++ b/src-tauri/src/commands/filesystem.rs
@@ -31,7 +31,7 @@ fn build_tree(dir_path: &Path) -> Vec<FileEntry> {
             continue;
         }
 
-        let modified = fs::metadata(&path)
+        let modified = entry.metadata()
             .and_then(|m| m.modified())
             .ok()
             .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
@@ -407,6 +407,12 @@ pub fn move_directory(source_path: String, target_dir: String) -> Result<MoveFil
 /// Returns the file path passed via CLI args (if any), consuming it so subsequent calls return None.
 #[tauri::command]
 pub fn get_initial_file(state: tauri::State<'_, crate::InitialFileState>) -> Option<String> {
+    state.0.lock().ok().and_then(|mut guard| guard.take())
+}
+
+/// Returns the folder path passed via --open-folder CLI arg (if any), consuming it.
+#[tauri::command]
+pub fn get_initial_folder(state: tauri::State<'_, crate::InitialFolderState>) -> Option<String> {
     state.0.lock().ok().and_then(|mut guard| guard.take())
 }
 

--- a/src-tauri/src/commands/jumplist.rs
+++ b/src-tauri/src/commands/jumplist.rs
@@ -1,0 +1,214 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Filters folder list: removes duplicates, non-existent dirs, caps at `max`.
+/// Preserves insertion order (most recent first).
+pub fn build_recent_folders(folders: &[String], max: usize) -> Vec<String> {
+    let mut seen = HashSet::new();
+    folders
+        .iter()
+        .filter(|p| {
+            let path = Path::new(p.as_str());
+            path.is_dir() && seen.insert((*p).clone())
+        })
+        .take(max)
+        .cloned()
+        .collect()
+}
+
+/// Updates the Windows taskbar jump list with a "Recent Folders" category.
+/// Each folder becomes a shell link that re-launches the app with that folder as argument.
+#[cfg(windows)]
+pub fn set_jump_list(folders: &[String], exe_path: &str) -> Result<(), String> {
+    use windows::core::HSTRING;
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
+        COINIT_APARTMENTTHREADED,
+    };
+    use windows::Win32::UI::Shell::{
+        DestinationList, EnumerableObjectCollection, ICustomDestinationList, IShellLinkW, ShellLink,
+    };
+    use windows::Win32::UI::Shell::Common::{IObjectArray, IObjectCollection};
+
+    unsafe {
+        // Initialize COM
+        CoInitializeEx(None, COINIT_APARTMENTTHREADED)
+            .ok()
+            .map_err(|e| format!("CoInitializeEx failed: {}", e))?;
+
+        let result = (|| -> Result<(), String> {
+            // Create the destination list
+            let dest_list: ICustomDestinationList =
+                CoCreateInstance(&DestinationList, None, CLSCTX_INPROC_SERVER)
+                    .map_err(|e| format!("Failed to create DestinationList: {}", e))?;
+
+            // Begin building the list
+            let mut max_slots: u32 = 0;
+            let _removed: IObjectArray = dest_list
+                .BeginList(&mut max_slots)
+                .map_err(|e| format!("BeginList failed: {}", e))?;
+
+            // Create a collection for our items
+            let collection: IObjectCollection =
+                CoCreateInstance(&EnumerableObjectCollection, None, CLSCTX_INPROC_SERVER)
+                    .map_err(|e| format!("Failed to create collection: {}", e))?;
+
+            // Add each folder as a shell link
+            let limit = (max_slots as usize).min(folders.len());
+            for folder in folders.iter().take(limit) {
+                let link: IShellLinkW =
+                    CoCreateInstance(&ShellLink, None, CLSCTX_INPROC_SERVER)
+                        .map_err(|e| format!("Failed to create ShellLink: {}", e))?;
+
+                // Set target to our exe
+                link.SetPath(&HSTRING::from(exe_path))
+                    .map_err(|e| format!("SetPath failed: {}", e))?;
+
+                // Set argument to the folder path (quoted for spaces)
+                let arg = format!("--open-folder \"{}\"", folder);
+                link.SetArguments(&HSTRING::from(arg.as_str()))
+                    .map_err(|e| format!("SetArguments failed: {}", e))?;
+
+                // Set display name to just the folder name
+                let display = Path::new(folder)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| folder.clone());
+                link.SetDescription(&HSTRING::from(display.as_str()))
+                    .map_err(|e| format!("SetDescription failed: {}", e))?;
+
+                // Set icon to a folder icon (shell32.dll index 3)
+                link.SetIconLocation(&HSTRING::from("shell32.dll"), 3)
+                    .map_err(|e| format!("SetIconLocation failed: {}", e))?;
+
+                collection
+                    .AddObject(&link)
+                    .map_err(|e| format!("AddObject failed: {}", e))?;
+            }
+
+            // Cast collection to IObjectArray for AppendCategory
+            let array: IObjectArray = windows::core::Interface::cast(&collection)
+                .map_err(|e| format!("Cast to IObjectArray failed: {}", e))?;
+
+            dest_list
+                .AppendCategory(&HSTRING::from("Recent Folders"), &array)
+                .map_err(|e| format!("AppendCategory failed: {}", e))?;
+
+            dest_list
+                .CommitList()
+                .map_err(|e| format!("CommitList failed: {}", e))?;
+
+            Ok(())
+        })();
+
+        CoUninitialize();
+        result
+    }
+}
+
+#[cfg(not(windows))]
+pub fn set_jump_list(_folders: &[String], _exe_path: &str) -> Result<(), String> {
+    Ok(()) // no-op on non-Windows
+}
+
+/// Tauri command: receives folder list from frontend, validates, and updates jump list.
+#[tauri::command]
+pub fn update_jump_list(folders: Vec<String>) -> Result<(), String> {
+    let valid = build_recent_folders(&folders, 10);
+    if valid.is_empty() {
+        return Ok(());
+    }
+    let exe = std::env::current_exe()
+        .map_err(|e| e.to_string())?
+        .to_string_lossy()
+        .to_string();
+    set_jump_list(&valid, &exe)
+}
+
+/// Tauri command: clears the jump list.
+#[tauri::command]
+pub fn clear_jump_list() -> Result<(), String> {
+    set_jump_list(&[], "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_build_recent_folders_deduplicates() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_string_lossy().to_string();
+
+        let folders = vec![path.clone(), path.clone(), path.clone()];
+        let result = build_recent_folders(&folders, 10);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], path);
+    }
+
+    #[test]
+    fn test_build_recent_folders_limits_to_max() {
+        // Create 15 temp directories
+        let dirs: Vec<_> = (0..15).map(|_| tempfile::tempdir().unwrap()).collect();
+        let folders: Vec<String> = dirs
+            .iter()
+            .map(|d| d.path().to_string_lossy().to_string())
+            .collect();
+
+        let result = build_recent_folders(&folders, 10);
+
+        assert_eq!(result.len(), 10);
+    }
+
+    #[test]
+    fn test_build_recent_folders_filters_nonexistent() {
+        let dir = tempfile::tempdir().unwrap();
+        let valid_path = dir.path().to_string_lossy().to_string();
+
+        let folders = vec![
+            "C:\\nonexistent\\fake\\path".to_string(),
+            valid_path.clone(),
+            "Z:\\also\\not\\real".to_string(),
+        ];
+        let result = build_recent_folders(&folders, 10);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], valid_path);
+    }
+
+    #[test]
+    fn test_build_recent_folders_preserves_order() {
+        let dir1 = tempfile::tempdir().unwrap();
+        let dir2 = tempfile::tempdir().unwrap();
+        let dir3 = tempfile::tempdir().unwrap();
+
+        let path1 = dir1.path().to_string_lossy().to_string();
+        let path2 = dir2.path().to_string_lossy().to_string();
+        let path3 = dir3.path().to_string_lossy().to_string();
+
+        let folders = vec![path1.clone(), path2.clone(), path3.clone()];
+        let result = build_recent_folders(&folders, 10);
+
+        assert_eq!(result, vec![path1, path2, path3]);
+    }
+
+    #[test]
+    fn test_build_recent_folders_empty_input() {
+        let result = build_recent_folders(&[], 10);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_build_recent_folders_filters_files_not_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("not-a-dir.txt");
+        fs::write(&file_path, "hello").unwrap();
+
+        let folders = vec![file_path.to_string_lossy().to_string()];
+        let result = build_recent_folders(&folders, 10);
+
+        assert!(result.is_empty());
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod diagram;
 pub mod filesystem;
+pub mod jumplist;
 pub mod watcher;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,9 @@ use std::sync::Mutex;
 /// Holds the file path passed via CLI args (if any). `.take()` ensures it's consumed once.
 pub struct InitialFileState(pub Mutex<Option<String>>);
 
+/// Holds a folder path passed via `--open-folder` CLI arg (from jump list). Consumed once.
+pub struct InitialFolderState(pub Mutex<Option<String>>);
+
 /// Reads the saved theme from the app data directory (written by the frontend).
 fn read_saved_theme(app: &tauri::App) -> Option<String> {
     let dir = tauri::Manager::path(app).app_data_dir().ok()?;
@@ -39,16 +42,40 @@ fn extract_file_arg(args: &[String]) -> Option<String> {
         })
 }
 
+/// Extracts a folder path from `--open-folder "path"` CLI arguments.
+/// Used when the app is launched from a jump list entry.
+fn extract_folder_arg(args: &[String]) -> Option<String> {
+    let mut iter = args.iter().skip(1);
+    while let Some(arg) = iter.next() {
+        if arg == "--open-folder" {
+            if let Some(folder) = iter.next() {
+                let path = Path::new(folder);
+                if path.exists() && path.is_dir() {
+                    return path.canonicalize().ok().map(|p| {
+                        let s = p.to_string_lossy().to_string();
+                        s.strip_prefix(r"\\?\").unwrap_or(&s).to_string()
+                    });
+                }
+            }
+            return None;
+        }
+    }
+    None
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .manage(WatcherState(Mutex::new(None)))
         .manage(InitialFileState(Mutex::new(None)))
+        .manage(InitialFolderState(Mutex::new(None)))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            // Second instance launched — extract file arg and emit event to existing window
-            if let Some(file_path) = extract_file_arg(&args) {
+            // Second instance launched — check for folder or file arg
+            if let Some(folder_path) = extract_folder_arg(&args) {
+                let _ = tauri::Emitter::emit(app, "open-folder", folder_path);
+            } else if let Some(file_path) = extract_file_arg(&args) {
                 let _ = tauri::Emitter::emit(app, "open-file", file_path);
             }
             // Focus the existing main window
@@ -66,9 +93,14 @@ pub fn run() {
                 )?;
             }
 
-            // Parse CLI args for an initial file to open
+            // Parse CLI args for an initial file or folder to open
             let args: Vec<String> = std::env::args().collect();
-            if let Some(file_path) = extract_file_arg(&args) {
+            if let Some(folder_path) = extract_folder_arg(&args) {
+                let state = tauri::Manager::state::<InitialFolderState>(app);
+                if let Ok(mut guard) = state.0.lock() {
+                    *guard = Some(folder_path);
+                };
+            } else if let Some(file_path) = extract_file_arg(&args) {
                 let state = tauri::Manager::state::<InitialFileState>(app);
                 if let Ok(mut guard) = state.0.lock() {
                     *guard = Some(file_path);
@@ -106,8 +138,11 @@ pub fn run() {
             commands::filesystem::move_directory,
             commands::filesystem::get_initial_file,
             commands::filesystem::save_theme,
+            commands::filesystem::get_initial_folder,
             commands::watcher::start_watching,
             commands::diagram::render_ascii_diagram,
+            commands::jumplist::update_jump_list,
+            commands::jumplist::clear_jump_list,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -178,6 +213,59 @@ mod tests {
             file.to_string_lossy().to_string(),
         ];
         let result = extract_file_arg(&args);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_folder_arg_finds_folder() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_string_lossy().to_string();
+
+        let args = vec![
+            "polarmd.exe".to_string(),
+            "--open-folder".to_string(),
+            path.clone(),
+        ];
+        let result = extract_folder_arg(&args);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_extract_folder_arg_returns_none_without_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_string_lossy().to_string();
+
+        let args = vec![
+            "polarmd.exe".to_string(),
+            path,
+        ];
+        let result = extract_folder_arg(&args);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_folder_arg_returns_none_for_nonexistent() {
+        let args = vec![
+            "polarmd.exe".to_string(),
+            "--open-folder".to_string(),
+            "C:\\nonexistent\\fake\\path".to_string(),
+        ];
+        let result = extract_folder_arg(&args);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_folder_arg_returns_none_for_file_not_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("file.txt");
+        fs::write(&file, "hello").unwrap();
+
+        let args = vec![
+            "polarmd.exe".to_string(),
+            "--open-folder".to_string(),
+            file.to_string_lossy().to_string(),
+        ];
+        let result = extract_folder_arg(&args);
         assert!(result.is_none());
     }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,6 +25,8 @@
     moveFile,
     moveDirectory,
     saveThemeFile,
+    updateJumpList,
+    getInitialFolder,
   } from "./lib/services/filesystem";
   import {
     saveLastSelectedPath,
@@ -39,6 +41,8 @@
     getOpenPanes,
     saveTheme,
     getTheme,
+    addRecentFolder,
+    getRecentFolders,
   } from "./lib/services/persistence";
   import { setMermaidTheme, setBobDarkMode } from "./lib/services/markdown";
   import { findFirstFile, filterEntries } from "./lib/services/tree-utils";
@@ -81,6 +85,7 @@
   let renamingPath = $state("");
   let renameError = $state("");
   let scrollToId = $state("");
+  let loading = $state(false);
   const recentOwnWrites = new Set<string>();
   let suppressWatcherUntil = 0;
   let savedPaneBeforeHelp: { path: string; content: string; editMode?: boolean } | null = null;
@@ -115,6 +120,11 @@
     } catch (e) {
       console.error("Failed to load directory tree:", e);
     }
+  }
+
+  function refreshJumpList(folder: string) {
+    const folders = addRecentFolder(folder);
+    updateJumpList(folders).catch(() => {}); // fire-and-forget
   }
 
   function createPaneId(): string {
@@ -291,7 +301,10 @@
     docsPath = path;
     panes = [];
     activePaneId = "";
+    loading = true;
+    refreshJumpList(path);
     await loadTree();
+    loading = false;
 
     // Restore last selected file if it exists in the new tree
     const lastPath = getLastSelectedPath();
@@ -322,6 +335,7 @@
     // Set docs path to the parent directory
     docsPath = parentDir;
     saveDocsFolder(parentDir);
+    refreshJumpList(parentDir);
     await loadTree();
 
     // Open the file in the active pane
@@ -753,6 +767,7 @@
   onMount(() => {
     let unlistenFileChanged: (() => void) | undefined;
     let unlistenOpenFile: (() => void) | undefined;
+    let unlistenOpenFolder: (() => void) | undefined;
 
     // Global keyboard shortcuts
     document.addEventListener("keydown", handleKeyDown);
@@ -768,9 +783,15 @@
     document.addEventListener("dragend", globalDragEnd);
 
     (async () => {
+      // Check if a folder was passed via --open-folder (jump list click)
+      const initialFolder = await getInitialFolder();
       // Check if a file was passed via CLI args or OS file association
-      const initialFile = await getInitialFile();
-      if (initialFile) {
+      const initialFile = !initialFolder ? await getInitialFile() : null;
+
+      if (initialFolder) {
+        saveDocsFolder(initialFolder);
+        await switchToFolder(initialFolder);
+      } else if (initialFile) {
         await openFileFromOS(initialFile);
       } else {
         // Normal startup: check for a saved folder, then fall back to Rust backend default
@@ -824,6 +845,12 @@
         }
       }
 
+      // Listen for folder opens from jump list clicks (single-instance plugin)
+      unlistenOpenFolder = await listen<string>("open-folder", (event) => {
+        saveDocsFolder(event.payload);
+        switchToFolder(event.payload);
+      });
+
       // Listen for file opens from second instances (single-instance plugin)
       unlistenOpenFile = await listen<string>("open-file", (event) => {
         openFileFromOS(event.payload);
@@ -872,12 +899,16 @@
       // Ensure theme file exists for next launch (handles upgrade from older versions)
       saveThemeFile(theme).catch(() => {});
 
+      // Rebuild jump list on startup to clean stale entries
+      updateJumpList(getRecentFolders()).catch(() => {});
+
       dismissSplash();
     })();
 
     return () => {
       unlistenFileChanged?.();
       unlistenOpenFile?.();
+      unlistenOpenFolder?.();
       document.removeEventListener("keydown", handleKeyDown);
       document.removeEventListener("dragover", globalDragOver);
       document.removeEventListener("drop", globalDrop);
@@ -887,7 +918,7 @@
 </script>
 
 <div class="app-layout">
-  <Sidebar entries={tree} {selectedPath} {selectedFolderPath} onselect={(path, event, lineContent) => handleSelect(path, event, lineContent)} onchangefolder={handleChangeFolder} {sortMode} onsortchange={handleSortChange} onhelp={handleHelp} {helpActive} {filterQuery} onfilterchange={handleFilterChange} {searchMode} onsearchmodechange={handleSearchModeChange} {searchResults} {searchQuery} onsearchchange={handleSearchChange} {isSearching} onnewfile={handleNewFile} onnewfolder={handleNewFolder} {creatingFile} {creatingFolder} oncreatenewfile={handleCreateNewFile} oncancelcreate={handleCancelCreate} oncreatenewfolder={handleCreateNewFolder} oncancelcreatefolder={handleCancelCreateFolder} {newFileError} {newFolderError} onfocuschange={handleFocusChange} onfolderselect={handleFolderSelect} onmovefile={handleMoveFile} {renamingPath} {renameError} onstartrename={handleStartRename} onconfirmrename={handleConfirmRename} oncancelrename={handleCancelRename} ondelete={handleDeleteFile} onsaveas={handleSaveAsForPath} {docsPath} {theme} onthemetoggle={handleThemeToggle} oncopypath={handleCopyPath} />
+  <Sidebar entries={tree} {selectedPath} {selectedFolderPath} onselect={(path, event, lineContent) => handleSelect(path, event, lineContent)} onchangefolder={handleChangeFolder} {sortMode} onsortchange={handleSortChange} onhelp={handleHelp} {helpActive} {filterQuery} onfilterchange={handleFilterChange} {searchMode} onsearchmodechange={handleSearchModeChange} {searchResults} {searchQuery} onsearchchange={handleSearchChange} {isSearching} onnewfile={handleNewFile} onnewfolder={handleNewFolder} {creatingFile} {creatingFolder} oncreatenewfile={handleCreateNewFile} oncancelcreate={handleCancelCreate} oncreatenewfolder={handleCreateNewFolder} oncancelcreatefolder={handleCancelCreateFolder} {newFileError} {newFolderError} onfocuschange={handleFocusChange} onfolderselect={handleFolderSelect} onmovefile={handleMoveFile} {renamingPath} {renameError} onstartrename={handleStartRename} onconfirmrename={handleConfirmRename} oncancelrename={handleCancelRename} ondelete={handleDeleteFile} onsaveas={handleSaveAsForPath} {docsPath} {theme} onthemetoggle={handleThemeToggle} oncopypath={handleCopyPath} {loading} />
   <ContentArea {panes} {activePaneId} {layoutMode} onlayoutchange={handleLayoutChange} onclosepane={handleClosePane} onactivatepane={handleActivatePane} ontoggleedit={handleToggleEdit} onsave={handleSave} onsaveas={handleSaveAsFromPane} {highlightText} {highlightKey} {theme} onfilelink={handleFileLink} {scrollToId} />
 </div>
 

--- a/src/lib/components/ContentArea.svelte
+++ b/src/lib/components/ContentArea.svelte
@@ -2,6 +2,7 @@
   import MarkdownViewer from "./MarkdownViewer.svelte";
   import EditablePane from "./EditablePane.svelte";
   import type { OpenPane, LayoutMode, ThemeType } from "../types";
+  import logoUrl from "../../../img/logo.png";
 
   let {
     panes = [],
@@ -46,7 +47,7 @@
 
 {#if panes.length === 0}
   <div class="empty-state" role="main" aria-label="Markdown viewer">
-    <div class="empty-icon">🐻‍❄️</div>
+    <img class="empty-logo" src={logoUrl} alt="Polar Markdown" />
     <h2>Polar Markdown</h2>
     <p>Select a markdown file from the sidebar to view it.</p>
   </div>
@@ -305,8 +306,16 @@
     gap: 12px;
   }
 
-  .empty-icon {
-    font-size: 48px;
+  .empty-logo {
+    width: 80px;
+    height: 80px;
+    object-fit: contain;
+    animation: pulse-logo 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse-logo {
+    0%, 100% { opacity: 0.7; transform: scale(1); }
+    50% { opacity: 1; transform: scale(1.05); }
   }
 
   .empty-state h2 {

--- a/src/lib/components/ContentArea.test.ts
+++ b/src/lib/components/ContentArea.test.ts
@@ -101,6 +101,21 @@ describe("ContentArea", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows app logo image in empty state instead of emoji", () => {
+    render(ContentArea, {
+      props: {
+        panes: [],
+        activePaneId: "",
+        layoutMode: "centered" as LayoutMode,
+      },
+    });
+
+    const logo = screen.getByAltText("Polar Markdown");
+    expect(logo).toBeInTheDocument();
+    expect(logo.tagName).toBe("IMG");
+    expect((logo as HTMLImageElement).src).toContain("logo.png");
+  });
+
   it("renders a single pane with filename", async () => {
     render(ContentArea, {
       props: {

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -48,6 +48,7 @@
     docsPath = "",
     theme = "aurora" as ThemeType,
     onthemetoggle,
+    loading = false,
   }: {
     entries: FileEntry[];
     selectedPath?: string;
@@ -90,6 +91,7 @@
     docsPath?: string;
     theme?: ThemeType;
     onthemetoggle?: () => void;
+    loading?: boolean;
   } = $props();
 
   const sortLabels: Record<SortMode, string> = {
@@ -303,11 +305,19 @@
         {/if}
       </div>
     {/if}
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-    <nav class="sidebar-content" class:nav-drag-over={navDragOver} onclick={handleNavClick} ondragover={handleNavDragOver} ondragleave={handleNavDragLeave} ondrop={handleNavDrop}>
-      <FileTree {entries} {selectedPath} {selectedFolderPath} {onselect} {onfocuschange} {onfolderselect} {onmovefile} {renamingPath} {renameError} {onstartrename} {onconfirmrename} {oncancelrename} {ondelete} {onsaveas} {oncopypath} docsPath={docsPath} />
-    </nav>
+    {#if loading}
+      <div class="skeleton-container">
+        {#each Array(7) as _, i}
+          <div class="skeleton-bar" style="width: {60 + (i * 7) % 30}%; animation-delay: {i * 0.08}s"></div>
+        {/each}
+      </div>
+    {:else}
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <nav class="sidebar-content" class:nav-drag-over={navDragOver} onclick={handleNavClick} ondragover={handleNavDragOver} ondragleave={handleNavDragLeave} ondrop={handleNavDrop}>
+        <FileTree {entries} {selectedPath} {selectedFolderPath} {onselect} {onfocuschange} {onfolderselect} {onmovefile} {renamingPath} {renameError} {onstartrename} {onconfirmrename} {oncancelrename} {ondelete} {onsaveas} {oncopypath} docsPath={docsPath} />
+      </nav>
+    {/if}
   {/if}
   {#if docsPath}
     <div class="folder-path" title={docsPath}>
@@ -582,5 +592,25 @@
     margin: 4px 0 0;
     color: var(--red);
     font-size: 12px;
+  }
+
+  .skeleton-container {
+    flex: 1;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .skeleton-bar {
+    height: 20px;
+    border-radius: 4px;
+    background: var(--border);
+    animation: skeleton-pulse 1.2s ease-in-out infinite;
+  }
+
+  @keyframes skeleton-pulse {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 0.7; }
   }
 </style>

--- a/src/lib/components/Sidebar.test.ts
+++ b/src/lib/components/Sidebar.test.ts
@@ -367,6 +367,25 @@ describe("Sidebar", () => {
     expect(onthemetoggle).toHaveBeenCalledOnce();
   });
 
+  it("shows skeleton bars when loading is true and entries are empty", () => {
+    render(Sidebar, {
+      props: { entries: [], selectedPath: "", onselect: vi.fn(), loading: true },
+    });
+
+    const skeletonBars = document.querySelectorAll(".skeleton-bar");
+    expect(skeletonBars.length).toBeGreaterThan(0);
+    expect(skeletonBars.length).toBe(7);
+  });
+
+  it("does not show skeleton bars when loading is false", () => {
+    render(Sidebar, {
+      props: { entries: [], selectedPath: "", onselect: vi.fn(), loading: false },
+    });
+
+    const skeletonBars = document.querySelectorAll(".skeleton-bar");
+    expect(skeletonBars.length).toBe(0);
+  });
+
   it("shows search results instead of file tree when searchMode is active with a query", () => {
     const searchResults = [
       { path: "/docs/readme.md", name: "readme.md", matches: [{ line_number: 1, line_content: "# README" }] },

--- a/src/lib/services/filesystem.test.ts
+++ b/src/lib/services/filesystem.test.ts
@@ -14,7 +14,7 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
 
 import { invoke } from "@tauri-apps/api/core";
 import { ask, open, save } from "@tauri-apps/plugin-dialog";
-import { readDirectoryTree, readFileContents, startWatching, getDocsPath, pickFolder, searchFiles, writeFileContents, createFile, renameFile, getInitialFile, deleteFile, deleteDirectory, confirmDelete, confirmDeleteFolder, saveFileAs, moveDirectory } from "./filesystem";
+import { readDirectoryTree, readFileContents, startWatching, getDocsPath, pickFolder, searchFiles, writeFileContents, createFile, renameFile, getInitialFile, deleteFile, deleteDirectory, confirmDelete, confirmDeleteFolder, saveFileAs, moveDirectory, updateJumpList, getInitialFolder } from "./filesystem";
 
 const mockOpen = vi.mocked(open);
 const mockAsk = vi.mocked(ask);
@@ -316,5 +316,36 @@ describe("confirmDeleteFolder", () => {
     const result = await confirmDeleteFolder("my-notes");
 
     expect(result).toBe(false);
+  });
+});
+
+describe("updateJumpList", () => {
+  it("calls invoke with correct command and folder list", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+
+    await updateJumpList(["C:\\docs", "C:\\notes"]);
+
+    expect(mockInvoke).toHaveBeenCalledWith("update_jump_list", {
+      folders: ["C:\\docs", "C:\\notes"],
+    });
+  });
+});
+
+describe("getInitialFolder", () => {
+  it("calls invoke with correct command", async () => {
+    mockInvoke.mockResolvedValue("C:\\docs");
+
+    const result = await getInitialFolder();
+
+    expect(mockInvoke).toHaveBeenCalledWith("get_initial_folder");
+    expect(result).toBe("C:\\docs");
+  });
+
+  it("returns null when no folder was passed", async () => {
+    mockInvoke.mockResolvedValue(null);
+
+    const result = await getInitialFolder();
+
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/services/filesystem.ts
+++ b/src/lib/services/filesystem.ts
@@ -100,6 +100,14 @@ export async function saveThemeFile(theme: string): Promise<void> {
   await invoke("save_theme", { theme });
 }
 
+export async function updateJumpList(folders: string[]): Promise<void> {
+  await invoke("update_jump_list", { folders });
+}
+
+export async function getInitialFolder(): Promise<string | null> {
+  return invoke<string | null>("get_initial_folder");
+}
+
 export async function pickFolder(): Promise<string | null> {
   const selected = await open({
     directory: true,

--- a/src/lib/services/persistence.test.ts
+++ b/src/lib/services/persistence.test.ts
@@ -14,6 +14,9 @@ import {
   getExpandedPaths,
   saveTheme,
   getTheme,
+  saveRecentFolders,
+  getRecentFolders,
+  addRecentFolder,
 } from "./persistence";
 
 const STORAGE_KEY = "polar-markdown:last-selected-path";
@@ -151,5 +154,43 @@ describe("saveTheme / getTheme", () => {
     saveTheme("glacier");
     saveTheme("aurora");
     expect(getTheme()).toBe("aurora");
+  });
+});
+
+describe("saveRecentFolders / getRecentFolders", () => {
+  it("round-trips an array of folder paths", () => {
+    saveRecentFolders(["C:\\docs", "C:\\notes"]);
+    expect(getRecentFolders()).toEqual(["C:\\docs", "C:\\notes"]);
+  });
+
+  it("returns empty array when nothing stored", () => {
+    expect(getRecentFolders()).toEqual([]);
+  });
+
+  it("returns empty array for corrupt JSON", () => {
+    localStorage.setItem("polar-markdown:recent-folders", "not-json");
+    expect(getRecentFolders()).toEqual([]);
+  });
+});
+
+describe("addRecentFolder", () => {
+  it("adds a new folder to the front", () => {
+    const result = addRecentFolder("C:\\docs");
+    expect(result).toEqual(["C:\\docs"]);
+    expect(getRecentFolders()).toEqual(["C:\\docs"]);
+  });
+
+  it("moves an existing folder to the front (deduplicates)", () => {
+    saveRecentFolders(["C:\\notes", "C:\\docs", "C:\\archive"]);
+    const result = addRecentFolder("C:\\docs");
+    expect(result).toEqual(["C:\\docs", "C:\\notes", "C:\\archive"]);
+  });
+
+  it("caps at 10 entries", () => {
+    const folders = Array.from({ length: 12 }, (_, i) => `C:\\folder${i}`);
+    saveRecentFolders(folders);
+    const result = addRecentFolder("C:\\new");
+    expect(result.length).toBe(10);
+    expect(result[0]).toBe("C:\\new");
   });
 });

--- a/src/lib/services/persistence.ts
+++ b/src/lib/services/persistence.ts
@@ -8,6 +8,7 @@ const SORT_MODE_KEY = "polar-markdown:sort-mode";
 const LAYOUT_MODE_KEY = "polar-markdown:layout-mode";
 const OPEN_PANES_KEY = "polar-markdown:open-panes";
 const EXPANDED_PATHS_KEY = "polar-markdown:expanded-paths";
+const RECENT_FOLDERS_KEY = "polar-markdown:recent-folders";
 const THEME_KEY = "polar-markdown:theme";
 
 export function saveLastSelectedPath(path: string): void {
@@ -68,6 +69,28 @@ export function getExpandedPaths(): string[] {
   } catch {
     return [];
   }
+}
+
+export function saveRecentFolders(folders: string[]): void {
+  localStorage.setItem(RECENT_FOLDERS_KEY, JSON.stringify(folders));
+}
+
+export function getRecentFolders(): string[] {
+  const stored = localStorage.getItem(RECENT_FOLDERS_KEY);
+  if (!stored) return [];
+  try {
+    return JSON.parse(stored);
+  } catch {
+    return [];
+  }
+}
+
+export function addRecentFolder(folder: string): string[] {
+  const existing = getRecentFolders();
+  const filtered = existing.filter((f) => f !== folder);
+  const updated = [folder, ...filtered].slice(0, 10);
+  saveRecentFolders(updated);
+  return updated;
 }
 
 export function saveTheme(theme: ThemeType): void {


### PR DESCRIPTION
## Summary
- **Windows Jump List:** Recent folders appear in taskbar jump list via COM API (`windows` crate 0.61). Clicking opens the folder in Polar Markdown via `--open-folder` CLI arg + single-instance event. Folders deduplicated/validated/capped at 10.
- **Folder loading skeleton:** Sidebar shows 7 animated pulsing skeleton bars during `loadTree()` so folder switches have visual feedback instead of appearing frozen.
- **Logo empty state:** Replaced bear emoji with actual app logo image (polar bear with sunglasses) in the content area empty state, with subtle pulse animation.
- **Rust perf:** `build_tree()` uses `entry.metadata()` (cached DirEntry) instead of `fs::metadata()` (separate syscall per file).

## Test plan
- [x] 506 tests passing (415 frontend + 91 Rust)
- [ ] Manual: Right-click taskbar icon — recent folders appear in jump list
- [ ] Manual: Click jump list folder — opens in Polar Markdown
- [ ] Manual: Switch folders via picker — skeleton shows while loading
- [ ] Manual: Close all panes — logo image renders (both Aurora and Glacier themes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)